### PR TITLE
DSNS-123

### DIFF
--- a/tests/integration_tests/ls_interim_prod_wagl.env
+++ b/tests/integration_tests/ls_interim_prod_wagl.env
@@ -5,4 +5,5 @@
 module use /g/data/v10/public/modules/modulefiles
 module use /g/data/v10/private/modules/modulefiles
 
-module load ard-pipeline/20221017-l9
+#module load ard-pipeline/20221017-l9
+module load ard-pipeline/20230227-l9

--- a/tests/integration_tests/s2_go_select.sh
+++ b/tests/integration_tests/s2_go_select.sh
@@ -14,7 +14,7 @@ else
     SSPATH=$HOME/sandbox/dea-ard-scene-select
 fi
 
-TEST_DATA=/g/data/u46/users/dsg456/test_data
+TEST_DATA=/g/data/u46/users/dsg547/test_data
 yamdir=' --yamls-dir '$TEST_DATA'/s2/autogen/yaml'
 
 # so it uses the dev scene select

--- a/tests/integration_tests/s2_interim_prod_wagl.env
+++ b/tests/integration_tests/s2_interim_prod_wagl.env
@@ -6,4 +6,6 @@ module use /g/data/v10/public/modules/modulefiles
 module use /g/data/v10/private/modules/modulefiles
 
 #module load ard-pipeline/20220315-s2-c3
-module load ard-pipeline/20220727-s2-c3
+#module load ard-pipeline/20220727-s2-c3
+module load ard-pipeline/20230227-s2-c3
+


### PR DESCRIPTION
    - integration tests for new ard-pipeline modules (ie.
      ard-pipeline/20230227-s2-c3 and ard-pipeline/20230227-l9)
    - fixed up a bug with the s2_go_select.sh script
      which was not getting to the path where test
      data was stored thus causing integration tests
      to fail