### PR TITLE
the --index-datacube-env is needed when archiving

### DIFF
--- a/tests/integration_tests/ls_go_select.sh
+++ b/tests/integration_tests/ls_go_select.sh
@@ -33,6 +33,6 @@ mkdir -p $pkgdir
 
 # '["usgs_ls8c_level1_2", "esa_s2am_level1_0"]'
 
-python3 $SSPATH/scene_select/ard_scene_select.py  --config ${USER}_dev.conf --products '["usgs_ls7e_level1_1", "usgs_ls8c_level1_1", "usgs_ls8c_level1_2", "usgs_ls9c_level1_2"]' --workdir $scratch/  --pkgdir  $pkgdir --logdir $scratch/ --env $PWD/ls_interim_prod_wagl.env --project u46 --walltime 02:30:00 --interim-days-wait 5 --allowed-codes Australian_AOI_107069_added.json --days-to-exclude '["2009-01-03:2009-01-05"]' --run-ard  #--index-datacube-env index-test-odc.env
+python3 $SSPATH/scene_select/ard_scene_select.py  --config ${USER}_dev.conf --products '["usgs_ls7e_level1_1", "usgs_ls8c_level1_1", "usgs_ls8c_level1_2", "usgs_ls9c_level1_2"]' --workdir $scratch/  --pkgdir  $pkgdir --logdir $scratch/ --env $PWD/ls_interim_prod_wagl.env --project u46 --walltime 02:30:00 --interim-days-wait 5 --allowed-codes Australian_AOI_107069_added.json --days-to-exclude '["2009-01-03:2009-01-05"]' --index-datacube-env index-test-odc.env --run-ard
 
 #ard-scene-select  --config dsg547_dev.conf --products '["usgs_ls8c_level1_2", "usgs_ls7e_level1_2"]' --workdir $scratch/  --pkgdir  $scratch/ --logdir $scratch/ --env $PWD/interim-prod-wagl.env --project u46 --walltime 02:30:00  --index-datacube-env index-test-odc.env  --interim-days-wait 5 --run-ard


### PR DESCRIPTION
minor fix to the integration tests