### PR TITLE
DSNS-79/102: successfully tested dea package 20221025 and the  h5 compression filter, 20230215

### DIFF
--- a/modules/go.sh
+++ b/modules/go.sh
@@ -2,5 +2,13 @@
 # do a fresh login before running this to avoid issues from
 # modules already loaded
 
-./package-module.sh "${2:-$(date +'%Y%m%d')}"
-#./package-module.sh  dev_${2:-$(date +'%Y%m%d')}
+# This script, by default, would run in the non production
+# environment. If a production run is required,
+# a --prod flag is to be provided to this script.
+if [[ $1 == "--prod" ]]; then
+    # production version
+    ./package-module.sh "${2:-$(date +'%Y%m%d')}" --prod
+else
+    # dev version
+    ./package-module.sh  dev_${2:-$(date +'%Y%m%d')}
+fi

--- a/modules/package-module.sh
+++ b/modules/package-module.sh
@@ -6,13 +6,17 @@ umask 002
 #unset PYTHONPATH
 
 echo "##########################"
-echo
-echo "module_dir = ${module_dir:=/g/data/v10/private/modules}"
-#echo "module_dir = ${module_dir:=/g/data/u46/users/dsg547/devmodules}"
+if [[ $1 == "--prod" ]]; then
+	echo "module_dir = ${module_dir:=/g/data/v10/private/modules}"
+else
+    # dev version
+	echo "module_dir = ${module_dir:=/g/data/u46/users/gy5636/devmodules}"
+fi
+
 echo "dea_module_dir = ${dea_module_dir:=/g/data/v10/public/modules}"
 echo
-echo "dea_module = ${dea_module:=dea/20200617}"
-echo "dep_module = ${dep_module:=h5-compression-filters/20200612}"
+echo "dea_module = ${dea_module:=dea/20221025}"
+echo "dep_module = ${dep_module:=h5-compression-filters/20230215}"
 dea_module_name=${dea_module%/*}
 instance=${dea_module_name##*-}
 echo "instance = ${instance}"

--- a/scripts/tickets/DSNS-102/load_new_test_module_20221025.sh
+++ b/scripts/tickets/DSNS-102/load_new_test_module_20221025.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [[ $HOSTNAME == *"gadi"* ]]; then
+	echo "If module load breaks check out a clean environment"
+	module use /g/data/v10/public/modules/modulefiles
+	module use /g/data/v10/private/modules/modulefiles
+	module use /g/data/u46/users/gy5636/devmodules/modulefiles # This refers to the dev package we created for testing
+	module use /g/data/u46/users/gy5636/modules/modulefiles # this should load up the h5 as the h5 is in "modules/modulefiles/h5-compression-filters/20230215"
+	module load ard-scene-select-py3-dea/dev_20230322 # Gordon - Dev - this is the package created on 20230223
+	echo "Just loaded the new module we are testing - 'load ard-scene-select-py3-dea/dev_20230322'"
+	echo "Performing ODCCONF system check now..."
+	echo $ODCCONF
+	datacube $ODCCONF system check
+	echo "ODCCONF - System check done"
+fi
+
+# observe the scratch directory below that is named against the 
+# current ticket we are working on
+mkdir -p scratch_DSNS_102
+
+SSPATH=$PWD/../../
+[[ ":$PYTHONPATH:" != *":$SSPATH:"* ]] && PYTHONPATH="$SSPATH:${PYTHONPATH}"
+
+# The module
+time ard-scene-select --workdir scratch_DSNS_102/  --pkgdir  scratch_DSNS_102/ --logdir scratch_DSNS_102/ --project u46 --walltime 10:00:00  --env /g/data/v10/projects/c3_ard/dea-ard-scene-select/scripts/prod/ard_env/prod-wagl-ls.env --products '["usgs_ls9c_level1_2"]' --scene-limit 999999 #--find-blocked
+
+echo "Done running ard scene select to test...."


### PR DESCRIPTION
 Can confirm that   they are stable. The committed changes will make it easier for us to test changes of a similar nature easier in the future.
 1. changes put in to create a dev package to test the new dea module 2022 10 25 and h5  compression module
 2. on dea-ard-scene-select/modules/, created the dev package by updating package_module.sh and ran go.sh
 3. created dea-ard-scene-select/scripts/tickets/DSNS-102/load_new_test_module_20221025.sh which loads the correct versions of the dea package and h5-compression-filter packages. This file is from example.sh