### PR TITLE
DSNS 79: fixes to ensure the current package builder works with the newly introduced --prod flag

### DIFF
--- a/modules/package-module.sh
+++ b/modules/package-module.sh
@@ -4,13 +4,12 @@ set -eu
 
 umask 002
 #unset PYTHONPATH
-
 echo "##########################"
-if [[ $1 == "--prod" ]]; then
-	echo "module_dir = ${module_dir:=/g/data/v10/private/modules}"
+if [[ $2 == "--prod" ]]; then
+    echo "prod mode: module_dir = ${module_dir:=/g/data/v10/private/modules}"
 else
     # dev version
-	echo "module_dir = ${module_dir:=/g/data/u46/users/gy5636/devmodules}"
+    echo "module_dir = ${module_dir:=/g/data/u46/users/${USER}/devmodules}"
 fi
 
 echo "dea_module_dir = ${dea_module_dir:=/g/data/v10/public/modules}"
@@ -27,7 +26,7 @@ export module_dir dea_module dep_module
 
 echoerr() { echo "$@" 1>&2; }
 
-if [[ $# != 1 ]] || [[ "$1" == "--help" ]]; then
+if [[ "$1" == "--help" ]]; then
 	echoerr
 	echoerr "Usage: $0 <version>"
 	exit 1


### PR DESCRIPTION
    go.sh:
        * updated the script so that calls to the script in production mode (with --prod will work)
        * updated the user directory from a hard coded one to the user id of the current user so that minimal changes will be required when one tries to build the package under non production mode     package-module.sh
        * Fixed an error whereby --prod was not recognised