### PR TITLE
DSNS-245: Adjustments to dea-ard-scene-select’s scene_select

### DIFF
--- a/scene_select/ard_scene_select.py
+++ b/scene_select/ard_scene_select.py
@@ -507,7 +507,6 @@ def l1_scenes_to_process(
     """Writes all the files returned from datacube for level1 to a file."""
     # pylint: disable=R0914
     # R0914: Too many local variables
-
     dc = datacube.Datacube(app="gen-list", config=config)
     l1_count = 0
     with open(outfile, "w") as fid:
@@ -541,8 +540,8 @@ def l1_scenes_to_process(
 @click.option(
     "--usgs-level1-files",
     type=click.Path(dir_okay=False, file_okay=True),
-    help="full path to a text files containing all "
-    "the level-1 USGS/ESA list to be filtered",
+    help="full path to a text file containing all "
+    "the level-1 USGS/ESA entries to be filtered",
 )
 @click.option(
     "--allowed-codes",
@@ -642,6 +641,11 @@ Does not work for multigranule zip files.",
     help="The base logging and scripts output directory.",
 )
 @click.option(
+    "--jobdir",
+    type=click.Path(file_okay=False, writable=True),
+    help="The start ard processing directory. Will be made if it does not exist.",
+)
+@click.option(
     "--pkgdir",
     type=click.Path(file_okay=False, writable=True),
     help="The base output packaged directory.",
@@ -680,6 +684,7 @@ def scene_select(
     config: click.Path,
     products: list,
     logdir: click.Path,
+    jobdir: click.Path,
     brdfdir: click.Path,
     wvdir: click.Path,
     stop_logging: bool,
@@ -705,7 +710,7 @@ def scene_select(
         walltime: str,
         email: str
 
-    :return: list of scenes to ARD process
+    :return: Nothing
     """
     # pylint: disable=R0913, R0914
     # R0913: Too many arguments
@@ -714,7 +719,11 @@ def scene_select(
     logdir = Path(logdir).resolve()
     # If we write a file we write it in the job dir
     # set up the scene select job dir in the log dir
-    jobdir = logdir.joinpath(FMT2.format(jobid=uuid.uuid4().hex[0:6]))
+    if jobdir is None:
+        logdir = Path(logdir).resolve()
+        jobdir = logdir.joinpath(FMT2.format(jobid=uuid.uuid4().hex[0:6]))
+    else:
+        jobdir = Path(jobdir).resolve()
     jobdir.mkdir(exist_ok=True)
 
     if not stop_logging:
@@ -753,7 +762,6 @@ def scene_select(
     )
 
     LOGGER.info("info", jobdir=str(jobdir))
-    print("Job directory: " + str(jobdir))
 
 
 if __name__ == "__main__":

--- a/tests/do_tests.sh
+++ b/tests/do_tests.sh
@@ -30,6 +30,3 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pytest -s -v $SCRIPT_DIR/test_*.py
 
 #./timing_check_ancillary.py
-
-# Clean up for test_ard_scene_select.py
-rm -rf temp_jobdir_testing_* temp_logdir_testing_*

--- a/tests/do_tests.sh
+++ b/tests/do_tests.sh
@@ -30,3 +30,6 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 pytest -s -v $SCRIPT_DIR/test_*.py
 
 #./timing_check_ancillary.py
+
+# Clean up for test_ard_scene_select.py
+rm -rf temp_jobdir_testing_* temp_logdir_testing_*

--- a/tests/odc_tests/launch_test.sh
+++ b/tests/odc_tests/launch_test.sh
@@ -37,6 +37,3 @@ else
   echo "Running all python test files"
   python3 -m pytest -v -s test*.py
 fi
-
-# Clean up
-rm -rf testing_jobdir* testing_logdir*

--- a/tests/odc_tests/launch_test.sh
+++ b/tests/odc_tests/launch_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This is a test launcher whereby we can give it any test 
+# or *.py to run on pytest
+
+if [[ $HOSTNAME == *"gadi"* ]]; then
+  echo "gadi - NCI"
+ 
+  module use /g/data/v10/public/modules/modulefiles;
+ 
+  module use /g/data/v10/private/modules/modulefiles;
+  # Needed for pytest to be loaded
+  module load dea/20221025
+  # module load ard-scene-select-py3-dea/dev_20230606
+  # module load ard-scene-select-py3-dea/20230615
+ 
+  echo "loaded the necessary packages as we run on nci gadi"
+ 
+  export ODC_TEST_DB_URL=postgresql://$USER"@deadev.nci.org.au/"$USER"_automated_testing"
+else
+  echo "This test needs to run on gadi (nci)"
+  exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+SSPATH=$DIR/../..
+ 
+[[ ":$PYTHONPATH:" != *":$SSPATH:"* ]] && PYTHONPATH="$SSPATH:${PYTHONPATH}"
+
+if [ -e "$1" ] && [ -n "$1" ]; then
+  # Run the specific file if it exists in the args
+  # and not an empty string
+  echo " Going to run test, '$1'..."
+  python3 -m pytest -v -s $1
+  echo " Completed running test, '$1'..."
+else
+  echo "Running all python test files"
+  python3 -m pytest -v -s test*.py
+fi
+
+# Clean up
+rm -rf testing_jobdir* testing_logdir*

--- a/tests/odc_tests/test_scene_select.py
+++ b/tests/odc_tests/test_scene_select.py
@@ -122,8 +122,9 @@ def test_scene_select_with_explicit_jobdir_with_db():
         # is expected to be non-None
         pytest.fail(f"Unexpected exception: {exception_message}")
     # clean up
-    shutil.rmtree(logdir)
-    shutil.rmtree(custom_jobdir)
+    finally:
+        shutil.rmtree(logdir)
+        shutil.rmtree(custom_jobdir)
 
 
 def test_scene_select_without_explicit_jobdir_with_db():
@@ -174,3 +175,5 @@ def test_scene_select_without_explicit_jobdir_with_db():
         # such as bad parameter types or NoneType when the argument
         # is expected to be non-None
         pytest.fail(f"Unexpected exception: {exception_message}")
+    finally:
+        shutil.rmtree(logdir)

--- a/tests/odc_tests/test_scene_select.py
+++ b/tests/odc_tests/test_scene_select.py
@@ -121,6 +121,9 @@ def test_scene_select_with_explicit_jobdir_with_db():
         # such as bad parameter types or NoneType when the argument
         # is expected to be non-None
         pytest.fail(f"Unexpected exception: {exception_message}")
+    # clean up
+    shutil.rmtree(logdir)
+    shutil.rmtree(custom_jobdir)
 
 
 def test_scene_select_without_explicit_jobdir_with_db():

--- a/tests/odc_tests/test_scene_select.py
+++ b/tests/odc_tests/test_scene_select.py
@@ -1,0 +1,173 @@
+"""
+    This test suite aims at ensuring changes to
+scene_select() are tested for maintainability and
+accuracy on how the function is to work.
+
+"""
+
+import shutil
+from pathlib import Path
+import uuid
+import os
+import pytest
+from click.testing import CliRunner
+
+from scene_select.ard_scene_select import (
+    scene_select,
+)
+
+ODC_FILES_DIR = Path(__file__).parent.joinpath("..", "test_data", "odc_setup").resolve()
+METADATA_TYPES = [
+    ODC_FILES_DIR / "metadata/eo3_landsat_l1.odc-type.yaml",
+    ODC_FILES_DIR / "metadata/eo3_landsat_ard.odc-type.yaml",
+]
+PRODUCTS = [
+    ODC_FILES_DIR / "eo3/l1_ls7.odc-product.yaml",
+    ODC_FILES_DIR / "eo3/l1_ls7.odc-product.yaml",
+    ODC_FILES_DIR / "eo3/l1_ls8_c2.odc-product.yaml",
+    ODC_FILES_DIR / "eo3/l1_ls9.odc-product.yaml",
+    ODC_FILES_DIR / "eo3/ard_ls8.odc-product.yaml",
+    ODC_FILES_DIR / "eo3/ard_ls7.odc-product.yaml",
+    ODC_FILES_DIR / "eo3/ard_ls9.odc-product.yaml",
+]
+
+DATAFILE_DIR = (
+    Path(__file__).parent.joinpath("..", "test_data", "ls9_reprocessing").resolve()
+)
+DATASET = [
+    DATAFILE_DIR
+    / "l1_Landsat_C2/092_081/LC90920812022172/LC09_L1TP_092081_20220621_20220621_02_T1.odc-metadata.yaml",
+    DATAFILE_DIR
+    / "ga_ls9c_ard_3/092/081/2022/06/21/ga_ls9c_ard_3-2-1_092081_2022-06-21_final.odc-metadata.yaml",
+    "/g/data/da82/AODH/USGS/L1/Landsat/C2/092_081/LC90920812022172/LC09_L1TP_092081_20220621_20220802_02_T1.odc-metadata.yaml",
+    "/g/data/da82/AODH/USGS/L1/Landsat/C2/102_076/LC91020762022178/LC09_L1TP_102076_20220627_20220802_02_T1.odc-metadata.yaml",
+    DATAFILE_DIR
+    / "l1_Landsat_C2/102_076/LC91020762022178/LC09_L1TP_102076_20220627_20220627_02_T1.odc-metadata.yaml",
+    DATAFILE_DIR
+    / "ga_ls9c_ard_3/102/076/2022/06/27/ga_ls9c_ard_3-2-1_102076_2022-06-27_final.odc-metadata.yaml",
+    DATAFILE_DIR
+    / "ga_ls9c_ard_3/092/081/2022/06/21/ga_ls9c_ard_3-2-1_092081_2022-06-21_final.odc-metadata.yaml",
+    DATAFILE_DIR
+    / "l1_Landsat_C2/095_074/LC90950742022177/LC09_L1TP_095074_20220626_20220802_02_T1.odc-metadata.yaml",
+    DATAFILE_DIR
+    / "ga_ls9c_ard_3/095/074/2022/06/26/ga_ls9c_ard_3-2-1_095074_2022-06-26_final.odc-metadata.yaml",
+]  # add
+
+
+# Set this to true and all the results
+# of the scene select run will be displayed
+VERBOSE = False
+
+pytestmark = pytest.mark.usefixtures("auto_odc_db")
+
+
+def test_scene_select_with_explicit_jobdir_with_db():
+    """
+    Given an explicit jobdir which does not exist,
+    we expect that directory to be created and used.
+    """
+    custom_jobdir = "testing_jobdir_" + str(uuid.uuid4()).replace("-", "")
+
+    logdir = "testing_logdir_" + str(uuid.uuid4()).replace("-", "")
+    os.mkdir(logdir)
+
+    cmd_params = [
+        "--logdir",
+        logdir,
+        "--jobdir",
+        custom_jobdir,
+    ]
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            scene_select,
+            cmd_params,
+        )
+
+        if VERBOSE:
+            print("RUNNING ARD SCENE SELECT")
+            print("***** results output ******")
+            print(result.output)
+            print("***** results exception ******")
+            print(result.exception)
+            print("***** results end ******")
+
+        # Depending on the type of error, the info on the
+        # error will either be in result.exception or result.output.
+        # result.output usually captures system errors whilst
+        # result.exception will capture errors with expected arguments.
+        # This usually traps process related errors such as
+        # missing arguments.
+        assert (
+            result.exception is None
+        ), f" Exception thrown in {result.exception}/{result.output}"
+
+        # Assert that when presented, the jobdir flag is accepted
+        assert (
+            "Error: No such option: --jobdir" not in result.output
+        ), "scene_select() doesn't recognise the job dir attribute"
+
+        assert (
+            len(os.listdir(custom_jobdir)) > 0
+        ), f" Nothing is inside the custom job directory, {custom_jobdir}"
+
+        # Assert that the file exists
+        assert os.path.exists(custom_jobdir), (
+            "Failed: Custom job dir, '" + str(custom_jobdir) + "' does not exist"
+        )
+    except Exception as exception_message:
+        # this traps errors thrown out by the scene_select() function
+        # such as bad parameter types or NoneType when the argument
+        # is expected to be non-None
+        pytest.fail(f"Unexpected exception: {exception_message}")
+
+
+def test_scene_select_without_explicit_jobdir_with_db():
+    """
+    Given no mention of jobdir, we expect the scene
+    select to not throw an exception.
+    Under the hood, a default directory to be used.
+    It will be made from an extract of a unique id
+    (given by a package called uuid) thus there is
+    no way we could get the jobid from the outside.
+    Based on ard reprocessed l1s:
+    jobdir = logdir.joinpath(DIR_TEMPLATE.format(jobid=uuid.uuid4().hex[0:6]))
+    """
+    logdir = "testing_logdir_" + str(uuid.uuid4()).replace("-", "")
+    os.mkdir(logdir)
+    try:
+        cmd_params = [
+            "--logdir",
+            logdir,
+        ]
+
+        runner = CliRunner()
+        result = runner.invoke(
+            scene_select,
+            cmd_params,
+        )
+
+        if VERBOSE:
+            print("RUNNING ARD SCENE SELECT")
+            print("***** results output ******")
+            print(result.output)
+            print("***** results exception ******")
+            print(result.exception)
+            print("***** results end ******")
+
+        # Depending on the type of error, the info on the
+        # error will either be in result.exception or result.output.
+        # result.output usually captures system errors whilst
+        # result.exception will capture errors with expected arguments.
+        # This usually traps process related errors such as
+        # missing arguments.
+        assert (
+            result.exception is None
+        ), f" Exception thrown in {result.exception}/{result.output}"
+
+    except Exception as exception_message:
+        # this traps errors thrown out by the scene_select() function
+        # such as bad parameter types or NoneType when the argument
+        # is expected to be non-None
+        pytest.fail(f"Unexpected exception: {exception_message}")

--- a/tests/test_ard_scene_select.py
+++ b/tests/test_ard_scene_select.py
@@ -200,9 +200,10 @@ def test_scene_select_with_explicit_jobdir_no_db():
         # such as bad parameter types or NoneType when the argument
         # is expected to be non-None
         pytest.fail(f"Unexpected exception: {exception_message}")
-    # clean up
-    shutil.rmtree(temp_dir)
-    shutil.rmtree(custom_jobdir)
+    finally:
+        # clean up
+        shutil.rmtree(temp_dir)
+        shutil.rmtree(custom_jobdir)
 
 
 def test_scene_select_no_explicit_jobdir_no_db():
@@ -263,5 +264,6 @@ def test_scene_select_no_explicit_jobdir_no_db():
         # such as bad parameter types or NoneType when the argument
         # is expected to be non-None
         pytest.fail(f"Unexpected exception: {exception_message}")
+    finally:
     # clean up
-    shutil.rmtree(temp_dir)
+        shutil.rmtree(temp_dir)

--- a/tests/test_ard_scene_select.py
+++ b/tests/test_ard_scene_select.py
@@ -202,6 +202,7 @@ def test_scene_select_with_explicit_jobdir_no_db():
         pytest.fail(f"Unexpected exception: {exception_message}")
     # clean up
     shutil.rmtree(temp_dir)
+    shutil.rmtree(custom_jobdir)
 
 
 def test_scene_select_no_explicit_jobdir_no_db():
@@ -262,3 +263,5 @@ def test_scene_select_no_explicit_jobdir_no_db():
         # such as bad parameter types or NoneType when the argument
         # is expected to be non-None
         pytest.fail(f"Unexpected exception: {exception_message}")
+    # clean up
+    shutil.rmtree(temp_dir)

--- a/tests/test_ard_scene_select.py
+++ b/tests/test_ard_scene_select.py
@@ -1,11 +1,19 @@
 #! /usr/bin/env python3
 
 import tempfile
+import shutil
 import datetime
 import pytz
 import re
-
-from scene_select.ard_scene_select import exclude_days
+import pytest
+import os
+import uuid
+from pathlib import Path
+from click.testing import CliRunner
+from scene_select.ard_scene_select import (
+    exclude_days,
+    scene_select,
+)
 
 
 def test_exclude_days():
@@ -17,15 +25,30 @@ def test_exclude_days():
     a_dt = datetime.datetime(2020, 9, 1, tzinfo=pytz.UTC)
     assert not exclude_days(range1, a_dt)
     a_dt = datetime.datetime(2020, 9, 6, tzinfo=pytz.UTC)
+
     assert not exclude_days(range1, a_dt)
     a_dt = datetime.datetime(
-        2020, 8, 8, hour=23, minute=59, second=59, microsecond=999999, tzinfo=pytz.UTC,
+        2020,
+        8,
+        8,
+        hour=23,
+        minute=59,
+        second=59,
+        microsecond=999999,
+        tzinfo=pytz.UTC,
     )
     assert not exclude_days(range1, a_dt)
 
     # excluded
     a_dt = datetime.datetime(
-        2020, 8, 30, hour=23, minute=59, second=59, microsecond=999999, tzinfo=pytz.UTC,
+        2020,
+        8,
+        30,
+        hour=23,
+        minute=59,
+        second=59,
+        microsecond=999999,
+        tzinfo=pytz.UTC,
     )
     assert exclude_days(range1, a_dt)
     a_dt = datetime.datetime(2020, 8, 9, tzinfo=pytz.UTC)
@@ -34,7 +57,14 @@ def test_exclude_days():
     range2 = ["2020-08-09:2020-08-09"]
     # excluded
     a_dt = datetime.datetime(
-        2020, 8, 9, hour=23, minute=59, second=59, microsecond=999999, tzinfo=pytz.UTC,
+        2020,
+        8,
+        9,
+        hour=23,
+        minute=59,
+        second=59,
+        microsecond=999999,
+        tzinfo=pytz.UTC,
     )
     assert exclude_days(range1, a_dt)
     a_dt = datetime.datetime(2020, 8, 9, tzinfo=pytz.UTC)
@@ -90,3 +120,145 @@ def test_s2_pattern():
     if not re.match(L8_C2_PATTERN, landsat_product_id):
         print(re.match(L8_C2_PATTERN, landsat_product_id))
         assert False
+
+
+# Set this to true and all the results
+# of the scene select run will be displayed
+VERBOSE = False
+
+
+@pytest.fixture(scope="function")
+def temp_directory():
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    shutil.rmtree(temp_dir)
+
+
+DATAFILE_DIR = Path(__file__).parent.joinpath("test_data").resolve()
+
+
+def test_scene_select_with_explicit_jobdir_no_db():
+    """
+    Given an explicit jobdir which does not exist,
+    we expect that directory to be created and used.
+    To run scene_select, we are passing in a file
+    containing all level-1 USGS/ESA entries to be filtered.
+    """
+
+    # Specify the directory path
+    custom_jobdir = "temp_jobdir_testing_" + str(uuid.uuid4()).replace("-", "")
+
+    temp_dir = "temp_logdir_testing_" + str(uuid.uuid4()).replace("-", "")
+    os.mkdir(temp_dir)
+
+    cmd_params = [
+        "--usgs-level1-files",
+        DATAFILE_DIR / "All_Landsat_Level1_Nci_Files.txt",
+        "--jobdir",
+        custom_jobdir,
+        "--logdir",
+        temp_dir,
+    ]
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            scene_select,
+            cmd_params,
+        )
+
+        if VERBOSE:
+            print("RUNNING ARD SCENE SELECT")
+            print("***** results output ******")
+            print(result.output)
+            print("***** results exception ******")
+            print(f"'{result.exception}'")
+            print("***** results end ******")
+
+        # Depending on the type of error, the info on the
+        # error will either be in result.exception or result.output.
+        # result.output usually captures system errors whilst
+        # result.exception will capture errors with expected arguments.
+        # This usually traps process related errors such as
+        # missing arguments.
+        assert (
+            result.exception is None
+        ), f" Exception thrown in {result.exception}/{result.output}"
+
+        # Assert that when presented, the jobdir flag is accepted
+        assert (
+            "Error: No such option: --jobdir" not in result.output
+        ), "scene_select() doesn't recognise the job dir attribute"
+
+        # Assert that the file exists
+        assert os.path.exists(
+            custom_jobdir
+        ), f"Failed: Custom job directory, '{custom_jobdir}' does not exist"
+
+    except Exception as exception_message:
+        # this traps errors thrown out by the scene_select() function
+        # such as bad parameter types or NoneType when the argument
+        # is expected to be non-None
+        pytest.fail(f"Unexpected exception: {exception_message}")
+    # clean up
+    shutil.rmtree(temp_dir)
+
+
+def test_scene_select_no_explicit_jobdir_no_db():
+    """
+    Given no mention of jobdir, we expect the scene
+    select to not throw an exception.
+    To run scene_select, we are passing in a file
+    containing all level-1 USGS/ESA entries to be filtered.
+    Under the hood, a default directory to be used.
+    It will be made from an extract of a unique id
+    (given by a package called uuid) thus there is
+    no way we could get the jobid from the outside.
+    Based on ard reprocessed l1s:
+    jobdir = logdir.joinpath(DIR_TEMPLATE.format(jobid=uuid.uuid4().hex[0:6]))
+    """
+
+    temp_dir = "temp_logdir_testing_" + str(uuid.uuid4()).replace("-", "")
+    os.mkdir(temp_dir)
+    # Clean up: Can't delete the temp directory (in job dir) even if we wanted
+    # to because it's been created by scene_select() which has its
+    # permissions and scope on it. Thus, this test doesn't have visibility
+    # on the temp directory
+
+    cmd_params = [
+        "--usgs-level1-files",
+        DATAFILE_DIR / "All_Landsat_Level1_Nci_Files.txt",
+        "--logdir",
+        temp_dir,
+    ]
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            scene_select,
+            cmd_params,
+        )
+
+        if VERBOSE:
+            print("RUNNING ARD SCENE SELECT")
+            print("***** results output ******")
+            print(result.output)
+            print("***** results exception ******")
+            print(result.exception)
+            print("***** results end ******")
+
+        # Depending on the type of error, the info on the
+        # error will either be in result.exception or result.output.
+        # result.output usually captures system errors whilst
+        # result.exception will capture errors with expected arguments.
+        # This usually traps process related errors such as
+        # missing arguments.
+        assert (
+            result.exception is None
+        ), f" Exception thrown in {result.exception}/{result.output}"
+
+    except Exception as exception_message:
+        # this traps errors thrown out by the scene_select() function
+        # such as bad parameter types or NoneType when the argument
+        # is expected to be non-None
+        pytest.fail(f"Unexpected exception: {exception_message}")

--- a/tests/test_data/odc_setup/eo3/ard_ls7.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/ard_ls7.odc-product.yaml
@@ -1,0 +1,230 @@
+---
+name: ga_ls7e_ard_3
+description: Geoscience Australia Landsat 7 Enhanced Thematic Mapper Plus Analysis Ready Data Collection 3
+metadata_type: eo3_landsat_ard
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ga_ls7e_ard_3
+  properties:
+     eo:platform: landsat-7
+     eo:instrument: ETM
+     odc:product_family: ard
+     odc:producer: ga.gov.au
+
+measurements:
+  # NBAR
+  - name: nbar_blue
+    aliases:
+      - nbar_band01
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_green
+    aliases:
+      - nbar_band02
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_red
+    aliases:
+      - nbar_band03
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_nir
+    aliases:
+      - nbar_band04
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_swir_1
+    aliases:
+      - nbar_band05
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_swir_2
+    aliases:
+      - nbar_band07
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_panchromatic
+    aliases:
+      - nbar_band08
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # NBART
+  - name: nbart_blue
+    aliases:
+      - nbart_band01
+      - blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_green
+    aliases:
+      - nbart_band02
+      - green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red
+    aliases:
+      - nbart_band03
+      - red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir
+    aliases:
+      - nbart_band04
+      - nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_1
+    aliases:
+      - nbart_band05
+      - swir_1
+      # Requested for backwards compatibility with previous collection
+      - swir1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_2
+    aliases:
+      - nbart_band07
+      - swir_2
+      # Requested for backwards compatibility with previous collection
+      - swir2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_panchromatic
+    aliases:
+      - nbart_band08
+      - panchromatic
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # Observation Attributes
+  - name: oa_fmask
+    aliases:
+      - fmask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      fmask:
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
+        description: Fmask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+          '3': shadow
+          '4': snow
+          '5': water
+  - name: oa_nbar_contiguity
+    aliases:
+      - nbar_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_nbart_contiguity
+    aliases:
+      - nbart_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_azimuthal_exiting
+    aliases:
+      - azimuthal_exiting
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_azimuthal_incident
+    aliases:
+      - azimuthal_incident
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_combined_terrain_shadow
+    aliases:
+      - combined_terrain_shadow
+    dtype: uint8
+    nodata: 255
+    units: '1'
+  - name: oa_exiting_angle
+    aliases:
+      - exiting_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_incident_angle
+    aliases:
+      - incident_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_azimuth
+    aliases:
+      - relative_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_slope
+    aliases:
+      - relative_slope
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_azimuth
+    aliases:
+      - satellite_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_view
+    aliases:
+      - satellite_view
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_azimuth
+    aliases:
+      - solar_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_zenith
+    aliases:
+      - solar_zenith
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_time_delta
+    aliases:
+      - time_delta
+    dtype: float32
+    nodata: .nan
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/ard_ls8.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/ard_ls8.odc-product.yaml
@@ -1,0 +1,243 @@
+---
+name: ga_ls8c_ard_3
+description: Geoscience Australia Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Analysis Ready Data Collection 3
+metadata_type: eo3_landsat_ard
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ga_ls8c_ard_3
+  properties:
+     eo:platform: landsat-8
+     eo:instrument: OLI_TIRS
+     odc:product_family: ard
+     odc:producer: ga.gov.au
+
+measurements:
+  # NBAR
+  - name: nbar_coastal_aerosol
+    aliases:
+      - nbar_band01
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_blue
+    aliases:
+      - nbar_band02
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_green
+    aliases:
+      - nbar_band03
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_red
+    aliases:
+      - nbar_band04
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_nir
+    aliases:
+      - nbar_band05
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_swir_1
+    aliases:
+      - nbar_band06
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_swir_2
+    aliases:
+      - nbar_band07
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_panchromatic
+    aliases:
+      - nbar_band08
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # NBART
+  - name: nbart_coastal_aerosol
+    aliases:
+      - nbart_band01
+      - coastal_aerosol
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_blue
+    aliases:
+      - nbart_band02
+      - blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_green
+    aliases:
+      - nbart_band03
+      - green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red
+    aliases:
+      - nbart_band04
+      - red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir
+    aliases:
+      - nbart_band05
+      - nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_1
+    aliases:
+      - nbart_band06
+      - swir_1
+      # Requested for backwards compatibility with previous collection
+      - swir1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_2
+    aliases:
+      - nbart_band07
+      - swir_2
+      # Requested for backwards compatibility with previous collection
+      - swir2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_panchromatic
+    aliases:
+      - nbart_band08
+      - panchromatic
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # Observation Attributes
+  - name: oa_fmask
+    aliases:
+      - fmask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      fmask:
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
+        description: Fmask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+          '3': shadow
+          '4': snow
+          '5': water
+  - name: oa_nbar_contiguity
+    aliases:
+      - nbar_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_nbart_contiguity
+    aliases:
+      - nbart_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_azimuthal_exiting
+    aliases:
+      - azimuthal_exiting
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_azimuthal_incident
+    aliases:
+      - azimuthal_incident
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_combined_terrain_shadow
+    aliases:
+      - combined_terrain_shadow
+    dtype: uint8
+    nodata: 255
+    units: '1'
+  - name: oa_exiting_angle
+    aliases:
+      - exiting_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_incident_angle
+    aliases:
+      - incident_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_azimuth
+    aliases:
+      - relative_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_slope
+    aliases:
+      - relative_slope
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_azimuth
+    aliases:
+      - satellite_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_view
+    aliases:
+      - satellite_view
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_azimuth
+    aliases:
+      - solar_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_zenith
+    aliases:
+      - solar_zenith
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_time_delta
+    aliases:
+      - time_delta
+    dtype: float32
+    nodata: .nan
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/ard_ls9.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/ard_ls9.odc-product.yaml
@@ -1,0 +1,243 @@
+---
+name: ga_ls9c_ard_3
+description: Geoscience Australia Landsat 9 Operational Land Imager and Thermal Infra-Red Scanner Analysis Ready Data Collection 3
+metadata_type: eo3_landsat_ard
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ga_ls9c_ard_3
+  properties:
+     eo:platform: landsat-9
+     eo:instrument: OLI_TIRS
+     odc:product_family: ard
+     odc:producer: ga.gov.au
+
+measurements:
+  # NBAR
+  - name: nbar_coastal_aerosol
+    aliases:
+      - nbar_band01
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_blue
+    aliases:
+      - nbar_band02
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_green
+    aliases:
+      - nbar_band03
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_red
+    aliases:
+      - nbar_band04
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_nir
+    aliases:
+      - nbar_band05
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_swir_1
+    aliases:
+      - nbar_band06
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_swir_2
+    aliases:
+      - nbar_band07
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbar_panchromatic
+    aliases:
+      - nbar_band08
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+  # NBART
+  - name: nbart_coastal_aerosol
+    aliases:
+      - nbart_band01
+      - coastal_aerosol
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_blue
+    aliases:
+      - nbart_band02
+      - blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_green
+    aliases:
+      - nbart_band03
+      - green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red
+    aliases:
+      - nbart_band04
+      - red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir
+    aliases:
+      - nbart_band05
+      - nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_1
+    aliases:
+      - nbart_band06
+      - swir_1
+      # Requested for backwards compatibility with previous collection
+      - swir1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_2
+    aliases:
+      - nbart_band07
+      - swir_2
+      # Requested for backwards compatibility with previous collection
+      - swir2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_panchromatic
+    aliases:
+      - nbart_band08
+      - panchromatic
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # Observation Attributes
+  - name: oa_fmask
+    aliases:
+      - fmask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      fmask:
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
+        description: Fmask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+          '3': shadow
+          '4': snow
+          '5': water
+  - name: oa_nbar_contiguity
+    aliases:
+      - nbar_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_nbart_contiguity
+    aliases:
+      - nbart_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_azimuthal_exiting
+    aliases:
+      - azimuthal_exiting
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_azimuthal_incident
+    aliases:
+      - azimuthal_incident
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_combined_terrain_shadow
+    aliases:
+      - combined_terrain_shadow
+    dtype: uint8
+    nodata: 255
+    units: '1'
+  - name: oa_exiting_angle
+    aliases:
+      - exiting_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_incident_angle
+    aliases:
+      - incident_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_azimuth
+    aliases:
+      - relative_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_slope
+    aliases:
+      - relative_slope
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_azimuth
+    aliases:
+      - satellite_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_view
+    aliases:
+      - satellite_view
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_azimuth
+    aliases:
+      - solar_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_zenith
+    aliases:
+      - solar_zenith
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_time_delta
+    aliases:
+      - time_delta
+    dtype: float32
+    nodata: .nan
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/l1_ls7.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/l1_ls7.odc-product.yaml
@@ -1,0 +1,66 @@
+---
+name: usgs_ls7e_level1_1
+description: United States Geological Survey Landsat 7 Enhanced Thematic Mapper Plus Level 1 Collection 1
+metadata_type: eo3_landsat_l1
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: usgs_ls7e_level1_1
+  properties:
+     eo:platform: landsat-7
+     eo:instrument: ETM
+     odc:product_family: level1
+     odc:producer: usgs.gov
+     landsat:collection_number: 1
+
+measurements:
+  - name: blue
+    aliases:
+      - band01
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: green
+    aliases:
+      - band02
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: red
+    aliases:
+      - band03
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: nir
+    aliases:
+      - band04
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_1
+    aliases:
+      - band05
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_2
+    aliases:
+      - band07
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+    #   - name: panchromatic
+    #     aliases:
+    #       - band08
+    #     dtype: uint16
+    #     nodata: 65535
+    #     units: '1'
+  - name: quality
+    aliases:
+      - bqa
+    dtype: uint16
+    nodata: 65535
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/l1_ls8.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/l1_ls8.odc-product.yaml
@@ -1,0 +1,90 @@
+---
+name: usgs_ls8c_level1_1
+description: United States Geological Survey Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Level 1 Collection 1
+metadata_type: eo3_landsat_l1
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: usgs_ls8c_level1_1
+  properties:
+     eo:platform: landsat-8
+     eo:instrument: OLI_TIRS
+     odc:product_family: level1
+     odc:producer: usgs.gov
+     landsat:collection_number: 1
+
+measurements:
+  - name: coastal_aerosol
+    aliases:
+      - band01
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: blue
+    aliases:
+      - band02
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: green
+    aliases:
+      - band03
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: red
+    aliases:
+      - band04
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: nir
+    aliases:
+      - band05
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_1
+    aliases:
+      - band06
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_2
+    aliases:
+      - band07
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: panchromatic
+    aliases:
+      - band08
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: cirrus
+    aliases:
+      - band09
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: lwir_1
+    aliases:
+      - band10
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: lwir_2
+    aliases:
+      - band11
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: quality
+    aliases:
+      - bqa
+    dtype: uint16
+    nodata: 65535
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/l1_ls8_c2.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/l1_ls8_c2.odc-product.yaml
@@ -1,0 +1,90 @@
+---
+name: usgs_ls8c_level1_2
+description: United States Geological Survey Landsat 8 Operational Land Imager and Thermal Infra-Red Scanner Level 1 Collection 2
+metadata_type: eo3_landsat_l1
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: usgs_ls8c_level1_2
+  properties:
+     eo:platform: landsat-8
+     eo:instrument: OLI_TIRS
+     odc:product_family: level1
+     odc:producer: usgs.gov
+     landsat:collection_number: 2
+
+measurements:
+  - name: coastal_aerosol
+    aliases:
+      - band01
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: blue
+    aliases:
+      - band02
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: green
+    aliases:
+      - band03
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: red
+    aliases:
+      - band04
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: nir
+    aliases:
+      - band05
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_1
+    aliases:
+      - band06
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: swir_2
+    aliases:
+      - band07
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: panchromatic
+    aliases:
+      - band08
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: cirrus
+    aliases:
+      - band09
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: lwir_1
+    aliases:
+      - band10
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: lwir_2
+    aliases:
+      - band11
+    dtype: uint16
+    nodata: 65535
+    units: '1'
+  - name: quality
+    aliases:
+      - bqa
+    dtype: uint16
+    nodata: 65535
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/l1_ls9.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/l1_ls9.odc-product.yaml
@@ -1,0 +1,110 @@
+---
+name: usgs_ls9c_level1_2
+description: United States Geological Survey Landsat 9 Operational Land Imager and Thermal Infra-Red Scanner Level 1 Collection 2
+metadata_type: eo3_landsat_l1
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: usgs_ls9c_level1_2
+  properties:
+     eo:platform: landsat-9
+     eo:instrument: OLI_TIRS
+     odc:product_family: level1
+     odc:producer: usgs.gov
+     landsat:collection_number: 2
+
+measurements:
+  - name: coastal_aerosol
+    aliases:
+      - band01
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: blue
+    aliases:
+      - band02
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: green
+    aliases:
+      - band03
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: red
+    aliases:
+      - band04
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: nir
+    aliases:
+      - band05
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_1
+    aliases:
+      - band06
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_2
+    aliases:
+      - band07
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: panchromatic
+    aliases:
+      - band08
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: cirrus
+    aliases:
+      - band09
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: lwir_1
+    aliases:
+      - band10
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: lwir_2
+    aliases:
+      - band11
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: quality
+    aliases:
+      - bqa
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: qa_radsat
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: solar_azimuth
+    dtype: int16
+    nodata: 0
+    units: '1'
+  - name: solar_zenith
+    dtype: int16
+    nodata: 0
+    units: '1'
+  - name: view_azimuth
+    dtype: int16
+    nodata: 0
+    units: '1'
+  - name: view_zenith
+    dtype: int16
+    nodata: 0
+    units: '1'

--- a/tests/test_data/odc_setup/metadata/eo3_landsat_ard.odc-type.yaml
+++ b/tests/test_data/odc_setup/metadata/eo3_landsat_ard.odc-type.yaml
@@ -1,0 +1,342 @@
+---
+name: eo3_landsat_ard
+description: EO3 for ARD Landsat Collection 3
+dataset:
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
+
+  grid_spatial: [grid_spatial, projection]
+  measurements: [measurements]
+  creation_dt: [properties, 'odc:processing_datetime']
+  label: [label]
+  format: [properties, 'odc:file_format']
+
+  search_fields:
+    platform:
+      description: Platform code
+      offset: [properties, 'eo:platform']
+      indexed: false
+
+    instrument:
+      description: Instrument name
+      offset: [properties, 'eo:instrument']
+      indexed: false
+
+    product_family:
+      description: Product family code
+      offset: [properties, 'odc:product_family']
+      indexed: false
+
+    region_code:
+      description: >
+        Spatial reference code from the provider.
+        For Landsat region_code is a scene path row:
+                '{:03d}{:03d}.format(path,row)'
+        For Sentinel it is MGRS code.
+        In general it is a unique string identifier
+        that datasets covering roughly the same spatial
+        region share.
+
+      offset: [properties, 'odc:region_code']
+
+    crs_raw:
+      description: The raw CRS string as it appears in metadata
+      offset: ['crs']
+      indexed: false
+
+    dataset_maturity:
+      description: One of - final|interim|nrt  (near real time)
+      offset: [properties, 'dea:dataset_maturity']
+
+    gqa:
+      description: GQA Circular error probable (90%)
+      type: double
+      offset: [properties, 'gqa:cep90']
+
+    cloud_cover:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains cloud pixels.
+
+        For these ARD products, this value comes from the Fmask algorithm.
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+
+    time:
+      description: Acquisition time range
+      type: datetime-range
+      min_offset:
+        - [properties, 'dtr:start_datetime']
+        - [properties, datetime]
+      max_offset:
+        - [properties, 'dtr:end_datetime']
+        - [properties, datetime]
+
+    # LonLat bounding box, generated on the fly from:
+    #  `grids`, `crs` and `geometry` of the new metadata format
+    #
+    # Bounding box is defined by two ranges:
+    #   [lon.begin, lon.end] -- Longitude
+    #   [lat.begin, lat.end] -- Latitude
+    #
+    # Note that STAC is using `bbox` for the same thing as following:
+    #
+    #     bbox: [left, bottom, right, top]
+    #              0      1      2     3
+    #             lon    lat    lon   lat
+    #
+    # But MetadataType does not support integer index keys, so...
+    #   BoundingBox: [lon.begin, lat.begin, lon.end, lat.end]
+
+    lon:
+      description: Longitude range
+      type: double-range
+      min_offset:
+        - [extent, lon, begin]
+      max_offset:
+        - [extent, lon, end]
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - [extent, lat, begin]
+      max_offset:
+        - [extent, lat, end]
+
+    landsat_product_id:
+      description: |
+        A Landsat Collection 1 Level-1 product identifier including the
+        Collection processing levels, processing date, collection number, and
+        collection tier category
+
+        (e.g. ‘LE07_L1TP_098084_20210307_20210308_02_RT’)
+      indexed: false
+      offset:
+        - properties
+        - landsat:landsat_product_id
+
+    landsat_scene_id:
+      description: |
+        A Landsat scene ID including WRS path and row, year and day,
+        ground station identifier and archive version number
+
+        (e.g. ‘LC80900852021066LGN00’)
+      indexed: false
+      offset:
+        - properties
+        - landsat:landsat_scene_id
+
+    # semi-auto generated below
+    eo_gsd:
+      # The nominal distance between pixel centers available, in meters.
+      description: |
+        Ground sampling distance of the sensor’s best resolution band
+        in metres; represents the size (or spatial resolution) of one pixel.
+      indexed: false
+      offset:
+        - properties
+        - eo:gsd
+      type: double
+    eo_sun_azimuth:
+      description: |
+        The azimuth angle of the sun at the moment of acquisition, in degree units measured clockwise from due north
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_azimuth
+      type: double
+    eo_sun_elevation:
+      description: |
+        The elevation angle of the sun at the moment of acquisition, in degree units relative to the horizon.
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_elevation
+      type: double
+
+
+    # ARD-specific
+    fmask_clear:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains clear land pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:clear
+      type: double
+    fmask_cloud_shadow:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains cloud shadow pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:cloud_shadow
+      type: double
+    fmask_snow:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains clear snow pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:snow
+      type: double
+    fmask_water:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains clear water pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:water
+      type: double
+    gqa_abs_iterative_mean_x:
+      description: |
+        Mean of the absolute values of the x-axis (east-to-west) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_x
+      type: double
+    gqa_abs_iterative_mean_xy:
+      description: |
+        Mean of the absolute values of the GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_xy
+      type: double
+    gqa_abs_iterative_mean_y:
+      description: |
+        Mean of the absolute values of the y-axis (north-to-south) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_y
+      type: double
+    gqa_abs_x:
+      description: |
+        Absolute value of the x-axis (east-to-west) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_x
+      type: double
+    gqa_abs_xy:
+      description: |
+        Absolute value of the total GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_xy
+      type: double
+    gqa_abs_y:
+      description: |
+        Absolute value of the y-axis (north-to-south) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_y
+      type: double
+    gqa_cep90:
+      description: |
+        Circular error probable (90%) of the values of the GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:cep90
+      type: double
+    gqa_iterative_mean_x:
+      description: |
+        Mean of the values of the x-axis (east-to-west) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_x
+      type: double
+    gqa_iterative_mean_xy:
+      description: |
+        Mean of the values of the GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_xy
+      type: double
+    gqa_iterative_mean_y:
+      description: |
+        Mean of the values of the y-axis (north-to-south) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_y
+      type: double
+    gqa_iterative_stddev_x:
+      description: |
+        Standard Deviation of the values of the x-axis (east-to-west) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_x
+      type: double
+    gqa_iterative_stddev_xy:
+      description: |
+        Standard Deviation of the values of the GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_xy
+      type: double
+    gqa_iterative_stddev_y:
+      description: |
+        Standard Deviation of the values of the y-axis (north-to-south) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_y
+      type: double
+    gqa_mean_x:
+      description: |
+        Mean of the values of the x-axis (east-to-west) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_x
+      type: double
+    gqa_mean_xy:
+      description: |
+        Mean of the values of the GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_xy
+      type: double
+    gqa_mean_y:
+      description: |
+        Mean of the values of the y-axis (north-to-south) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_y
+      type: double
+    gqa_stddev_x:
+      description: |
+        Standard Deviation of the values of the x-axis (east-to-west) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_x
+      type: double
+    gqa_stddev_xy:
+      description: |
+        Standard Deviation of the values of the GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_xy
+      type: double
+    gqa_stddev_y:
+      description: |
+        Standard Deviation of the values of the y-axis (north-to-south) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_y
+      type: double

--- a/tests/test_data/odc_setup/metadata/eo3_landsat_l1.odc-type.yaml
+++ b/tests/test_data/odc_setup/metadata/eo3_landsat_l1.odc-type.yaml
@@ -1,0 +1,151 @@
+---
+name: eo3_landsat_l1
+description: EO3 for Level 1 Landsat, GA Collection 3
+dataset:
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
+
+  grid_spatial: [grid_spatial, projection]
+  measurements: [measurements]
+  creation_dt: [properties, 'odc:processing_datetime']
+  label: [label]
+  format: [properties, 'odc:file_format']
+
+  search_fields:
+    platform:
+      description: Platform code
+      offset: [properties, 'eo:platform']
+      indexed: false
+
+    instrument:
+      description: Instrument name
+      offset: [properties, 'eo:instrument']
+      indexed: false
+
+    product_family:
+      description: Product family code
+      offset: [properties, 'odc:product_family']
+      indexed: false
+
+    region_code:
+      description: >
+        Spatial reference code from the provider.
+        For Landsat region_code is a scene path row:
+                '{:03d}{:03d}.format(path,row)'.
+        For Sentinel it is MGRS code.
+        In general it is a unique string identifier that datasets
+        covering roughly the same spatial region share.
+
+      offset: [properties, 'odc:region_code']
+
+    crs_raw:
+      description: The raw CRS string as it appears in metadata
+      offset: ['crs']
+      indexed: false
+
+    cloud_cover:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains cloud pixels.
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+
+    time:
+      description: Acquisition time range
+      type: datetime-range
+      min_offset:
+        - [properties, 'dtr:start_datetime']
+        - [properties, datetime]
+      max_offset:
+        - [properties, 'dtr:end_datetime']
+        - [properties, datetime]
+
+    # LonLat bounding box, generated on the fly from:
+    #  `grids`, `crs` and `geometry` of the new metadata format
+    #
+    # Bounding box is defined by two ranges:
+    #   [lon.begin, lon.end] -- Longitude
+    #   [lat.begin, lat.end] -- Latitude
+    #
+    # Note that STAC is using `bbox` for the same thing as following:
+    #
+    #     bbox: [left, bottom, right, top]
+    #              0      1      2     3
+    #             lon    lat    lon   lat
+    #
+    # But MetadataType does not support integer index keys, so...
+    #   BoundingBox: [lon.begin, lat.begin, lon.end, lat.end]
+
+    lon:
+      description: Longitude range
+      type: double-range
+      min_offset:
+        - [extent, lon, begin]
+      max_offset:
+        - [extent, lon, end]
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - [extent, lat, begin]
+      max_offset:
+        - [extent, lat, end]
+
+    # semi-auto generated below
+    eo_gsd:
+      # The nominal distance between pixel centers available, in meters.
+      description: |
+        Ground sampling distance of the sensor’s best resolution band
+        in metres; represents the size (or spatial resolution) of one pixel.
+      indexed: false
+      offset:
+        - properties
+        - eo:gsd
+      type: double
+    eo_sun_azimuth:
+      description: |
+        The azimuth angle of the sun at the moment of acquisition, in degree units measured clockwise from due north
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_azimuth
+      type: double
+    eo_sun_elevation:
+      description: |
+        The elevation angle of the sun at the moment of acquisition, in degree units relative to the horizon.
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_elevation
+      type: double
+
+    # Level 1 fields
+    landsat_product_id:
+      description: |
+        A Landsat Collection 1 Level-1 product identifier including the
+        Collection processing levels, processing date, collection number, and
+        collection tier category
+
+        (e.g. ‘LE07_L1TP_098084_20210307_20210308_02_RT’)
+      indexed: false
+      offset:
+        - properties
+        - landsat:landsat_product_id
+
+    landsat_scene_id:
+      description: |
+        A Landsat scene ID including WRS path and row, year and day,
+        ground station identifier and archive version number
+
+        (e.g. ‘LC80900852021066LGN00’)
+      indexed: false
+      offset:
+        - properties
+        - landsat:landsat_scene_id
+
+    landsat_data_type:
+      description: "Landsat Data Type (eg. 'L1T')"
+      indexed: false
+      offset:
+        - properties
+        - landsat:data_type

--- a/tests/test_data/odc_setup/metadata/eo3_sentinel.odc-type.yaml
+++ b/tests/test_data/odc_setup/metadata/eo3_sentinel.odc-type.yaml
@@ -1,0 +1,158 @@
+---
+name: eo3_sentinel
+description: EO3 with common Sentinel fields
+dataset:
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
+
+  grid_spatial: [grid_spatial, projection]
+  measurements: [measurements]
+  creation_dt: [properties, 'odc:processing_datetime']
+  label: [label]
+  format: [properties, 'odc:file_format']
+
+  search_fields:
+    platform:
+      description: Platform code
+      offset: [properties, 'eo:platform']
+      indexed: false
+
+    instrument:
+      description: Instrument name
+      offset: [properties, 'eo:instrument']
+      indexed: false
+
+    product_family:
+      description: Product family code
+      offset: [properties, 'odc:product_family']
+      indexed: false
+
+    region_code:
+      description: >
+        Spatial reference code from the provider.
+
+        For Sentinel it is MGRS code.
+
+      offset: [properties, 'odc:region_code']
+
+    crs_raw:
+      description: |
+        The raw CRS string as it appears in metadata
+
+        (e.g. ‘epsg:32654’)
+      offset: ['crs']
+      indexed: false
+
+    dataset_maturity:
+      description: |
+        One of - final|interim|nrt  (near real time)
+
+        The maturity level of the dataset; options include ‘nrt’
+        (ARD processing date less than 48 hours after acquisition date),
+        ‘interim’ (processed using fallback water vapour or BRDF data) and
+        ‘final’
+      offset: [properties, 'dea:dataset_maturity']
+      indexed: false
+
+    cloud_cover:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains cloud pixels
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+
+    time:
+      description: Acquisition time range
+      type: datetime-range
+      min_offset:
+        - [properties, 'dtr:start_datetime']
+        - [properties, datetime]
+      max_offset:
+        - [properties, 'dtr:end_datetime']
+        - [properties, datetime]
+
+    # LonLat bounding box, generated on the fly from:
+    #  `grids`, `crs` and `geometry` of the new metadata format
+    #
+    # Bounding box is defined by two ranges:
+    #   [lon.begin, lon.end] -- Longitude
+    #   [lat.begin, lat.end] -- Latitude
+    #
+    # Note that STAC is using `bbox` for the same thing as following:
+    #
+    #     bbox: [left, bottom, right, top]
+    #              0      1      2     3
+    #             lon    lat    lon   lat
+    #
+    # But MetadataType does not support integer index keys, so...
+    #   BoundingBox: [lon.begin, lat.begin, lon.end, lat.end]
+
+    lon:
+      description: Longitude range
+      type: double-range
+      min_offset:
+        - [extent, lon, begin]
+      max_offset:
+        - [extent, lon, end]
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - [extent, lat, begin]
+      max_offset:
+        - [extent, lat, end]
+
+    # semi-auto generated below
+    eo_gsd:
+      # The nominal distance between pixel centers available, in meters.
+      description: |
+        Ground sampling distance of the sensor’s best resolution band
+        in metres; represents the size (or spatial resolution) of one pixel.
+      indexed: false
+      offset:
+        - properties
+        - eo:gsd
+      type: double
+    eo_sun_azimuth:
+      description: |
+        The azimuth angle of the sun at the moment of acquisition, in degree units measured clockwise from due north
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_azimuth
+      type: double
+    eo_sun_elevation:
+      description: |
+        The elevation angle of the sun at the moment of acquisition, in degree units relative to the horizon.
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_elevation
+      type: double
+    sentinel_product_name:
+      description: |
+        ESA product URI, with the '.SAFE' ending removed.
+
+        (e.g. 'S2A_MSIL1C_20220303T000731_N0400_R073_T56LNM_20220303T012845')
+      indexed: false
+      offset:
+        - properties
+        - sentinel:product_name
+    sentinel_tile_id:
+      description: |
+          Granule ID according to the ESA naming convention
+
+          (e.g. ‘S2A_OPER_MSI_L1C_TL_SGS__20161214T040601_A007721_T53KRB_N02.04’)
+      indexed: false
+      offset:
+        - properties
+        - sentinel:sentinel_tile_id
+    sentinel_datastrip_id:
+      description: |
+          Unique identifier for a datastrip relative to a given Datatake.
+
+          (e.g. ‘S2A_OPER_MSI_L1C_DS_SGS__20161214T040601_S20161214T005840_N02.04’)
+      indexed: false
+      offset:
+        - properties
+        - sentinel:datastrip_id

--- a/tests/test_data/odc_setup/metadata/eo3_sentinel_ard.odc-type.yaml
+++ b/tests/test_data/odc_setup/metadata/eo3_sentinel_ard.odc-type.yaml
@@ -1,0 +1,359 @@
+---
+name: eo3_sentinel_ard
+description: EO3 for Sentinel 2 ARD
+dataset:
+  id: [id]  # No longer configurable in newer ODCs.
+  sources: [lineage, source_datasets]  # No longer configurable in newer ODCs.
+
+  grid_spatial: [grid_spatial, projection]
+  measurements: [measurements]
+  creation_dt: [properties, 'odc:processing_datetime']
+  label: [label]
+  format: [properties, 'odc:file_format']
+
+  search_fields:
+    platform:
+      description: Platform code
+      offset: [properties, 'eo:platform']
+      indexed: false
+
+    instrument:
+      description: Instrument name
+      offset: [properties, 'eo:instrument']
+      indexed: false
+
+    product_family:
+      description: Product family code
+      offset: [properties, 'odc:product_family']
+      indexed: false
+
+    region_code:
+      description: >
+        Spatial reference code from the provider.
+
+        For Sentinel it is MGRS code.
+
+      offset: [properties, 'odc:region_code']
+
+    crs_raw:
+      description: |
+        The raw CRS string as it appears in metadata
+
+        (e.g. ‘epsg:32654’)
+      offset: ['crs']
+      indexed: false
+
+    dataset_maturity:
+      description: One of - final|interim|nrt  (near real time)
+      offset: [properties, 'dea:dataset_maturity']
+      indexed: false
+
+    cloud_cover:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains cloud pixels.
+
+        For these ARD products, this value comes from the Fmask algorithm.
+      type: double
+      offset: [properties, 'eo:cloud_cover']
+
+    time:
+      description: Acquisition time range
+      type: datetime-range
+      min_offset:
+        - [properties, 'dtr:start_datetime']
+        - [properties, datetime]
+      max_offset:
+        - [properties, 'dtr:end_datetime']
+        - [properties, datetime]
+
+    # LonLat bounding box, generated on the fly from:
+    #  `grids`, `crs` and `geometry` of the new metadata format
+    #
+    # Bounding box is defined by two ranges:
+    #   [lon.begin, lon.end] -- Longitude
+    #   [lat.begin, lat.end] -- Latitude
+    #
+    # Note that STAC is using `bbox` for the same thing as following:
+    #
+    #     bbox: [left, bottom, right, top]
+    #              0      1      2     3
+    #             lon    lat    lon   lat
+    #
+    # But MetadataType does not support integer index keys, so...
+    #   BoundingBox: [lon.begin, lat.begin, lon.end, lat.end]
+
+    lon:
+      description: Longitude range
+      type: double-range
+      min_offset:
+        - [extent, lon, begin]
+      max_offset:
+        - [extent, lon, end]
+
+    lat:
+      description: Latitude range
+      type: double-range
+      min_offset:
+        - [extent, lat, begin]
+      max_offset:
+        - [extent, lat, end]
+
+    # semi-auto generated below
+    # The proportion (from 0 to 100) of the dataset's valid data area that contains clear land pixels according to the Fmask algorithm
+
+    eo_gsd:
+      # The nominal distance between pixel centers available, in meters.
+      description: |
+        Ground sampling distance of the sensor’s best resolution band
+        in metres; represents the size (or spatial resolution) of one pixel.
+      indexed: false
+      offset:
+        - properties
+        - eo:gsd
+      type: double
+    eo_sun_azimuth:
+      description: |
+        The azimuth angle of the sun at the moment of acquisition, in degree units measured clockwise from due north
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_azimuth
+      type: double
+    eo_sun_elevation:
+      description: |
+        The elevation angle of the sun at the moment of acquisition, in degree units relative to the horizon.
+      indexed: false
+      offset:
+        - properties
+        - eo:sun_elevation
+      type: double
+
+
+    # Sentinel-specific.
+    sentinel_product_name:
+      description: |
+        ESA product URI, with the '.SAFE' ending removed.
+
+        (e.g. 'S2A_MSIL1C_20220303T000731_N0400_R073_T56LNM_20220303T012845')
+      indexed: false
+      offset:
+        - properties
+        - sentinel:product_name
+    sentinel_tile_id:
+      description: |
+          Granule ID according to the ESA naming convention
+
+          (e.g. ‘S2A_OPER_MSI_L1C_TL_SGS__20161214T040601_A007721_T53KRB_N02.04’)
+      indexed: false
+      offset:
+        - properties
+        - sentinel:sentinel_tile_id
+    sentinel_datastrip_id:
+      description: |
+          Unique identifier for a datastrip relative to a given Datatake.
+
+          (e.g. ‘S2A_OPER_MSI_L1C_DS_SGS__20161214T040601_S20161214T005840_N02.04’)
+      indexed: false
+      offset:
+        - properties
+        - sentinel:datastrip_id
+
+    # ARD-specific
+    fmask_clear:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains clear land pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:clear
+      type: double
+    fmask_cloud_shadow:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains cloud shadow pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:cloud_shadow
+      type: double
+    fmask_snow:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains clear snow pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:snow
+      type: double
+    fmask_water:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains clear water pixels according to the Fmask algorithm
+      indexed: false
+      offset:
+        - properties
+        - fmask:water
+      type: double
+    gqa_abs_iterative_mean_x:
+      description: |
+        Mean of the absolute values of the x-axis (east-to-west) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_x
+      type: double
+    gqa_abs_iterative_mean_xy:
+      description: |
+        Mean of the absolute values of the GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_xy
+      type: double
+    gqa_abs_iterative_mean_y:
+      description: |
+        Mean of the absolute values of the y-axis (north-to-south) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_iterative_mean_y
+      type: double
+    gqa_abs_x:
+      description: |
+        Absolute value of the x-axis (east-to-west) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_x
+      type: double
+    gqa_abs_xy:
+      description: |
+        Absolute value of the total GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_xy
+      type: double
+    gqa_abs_y:
+      description: |
+        Absolute value of the y-axis (north-to-south) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:abs_y
+      type: double
+    gqa_cep90:
+      description: |
+        Circular error probable (90%) of the values of the GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:cep90
+      type: double
+    gqa_iterative_mean_x:
+      description: |
+        Mean of the values of the x-axis (east-to-west) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_x
+      type: double
+    gqa_iterative_mean_xy:
+      description: |
+        Mean of the values of the GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_xy
+      type: double
+    gqa_iterative_mean_y:
+      description: |
+        Mean of the values of the y-axis (north-to-south) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_mean_y
+      type: double
+    gqa_iterative_stddev_x:
+      description: |
+        Standard Deviation of the values of the x-axis (east-to-west) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_x
+      type: double
+    gqa_iterative_stddev_xy:
+      description: |
+        Standard Deviation of the values of the GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_xy
+      type: double
+    gqa_iterative_stddev_y:
+      description: |
+        Standard Deviation of the values of the y-axis (north-to-south) GCP residuals after removal of outliers, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:iterative_stddev_y
+      type: double
+    gqa_mean_x:
+      description: |
+        Mean of the values of the x-axis (east-to-west) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_x
+      type: double
+    gqa_mean_xy:
+      description: |
+        Mean of the values of the GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_xy
+      type: double
+    gqa_mean_y:
+      description: |
+        Mean of the values of the y-axis (north-to-south) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:mean_y
+      type: double
+    gqa_stddev_x:
+      description: |
+        Standard Deviation of the values of the x-axis (east-to-west) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_x
+      type: double
+    gqa_stddev_xy:
+      description: |
+        Standard Deviation of the values of the GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_xy
+      type: double
+    gqa_stddev_y:
+      description: |
+        Standard Deviation of the values of the y-axis (north-to-south) GCP residuals, in pixel units based on a 25 metre resolution reference image (i.e. 0.2 = 5 metres)
+      indexed: false
+      offset:
+        - properties
+        - gqa:stddev_y
+      type: double
+    s2cloudless_clear:
+      type: double
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains clear land pixels according to s3cloudless
+      offset:
+      - properties
+      - "s2cloudless:clear"
+    s2cloudless_cloud:
+      description: |
+        The proportion (from 0 to 100) of the dataset's valid data area that contains cloud land pixels according to s3cloudless
+      type: double
+      offset:
+      - properties
+      - "s2cloudless:cloud"


### PR DESCRIPTION
        A. Missing return value (based on doc) - based on
        https://github.com/GeoscienceAustralia/dea-ard-scene-select/blob/master/scene_select/ard_scene_select.py#L708,
        the function is supposed to return a list of files it is to process but returns
        nothing. Had a discussion with @Duncan Gray and it’s been decided that we
        update the documentation to mention it returns nothing.
    
        B. Extended scene_select to accept an explicit job dir argument for more control and
        consistency - Doing this would mean consistency across ard scene select and ard
        reprocessed l1s and allows more control as to where we want job related files
        are written to. As scene_select() works with either a database backend,
        OR a datafile (via the --usgs-level1-files attribute), the accompanying
        unit tests cover both forms of execution.

