### PR TITLE
DSNS 239: R3.1 tests 

### DIFF
--- a/tests/integration_tests/test_ard_landsat_unfiltered_scenes_r1_1.py
+++ b/tests/integration_tests/test_ard_landsat_unfiltered_scenes_r1_1.py
@@ -5,16 +5,16 @@
 """
 from collections import Counter
 from pathlib import Path
-from typing import List
+import os
 from click.testing import CliRunner
 import pytest
-import os
 from scene_select.ard_scene_select import (
     scene_select,
 )
 
 from util import (
     get_list_from_file,
+    get_expected_file_paths,
 )
 
 METADATA_DIR = (
@@ -60,11 +60,6 @@ DATASETS = [
     ),
 ]
 
-
-def get_expected_file_paths() -> List:
-    return [file_path.replace(".odc-metadata.yaml", ".tar") for file_path in DATASETS]
-
-
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
@@ -95,7 +90,7 @@ def test_ard_landsat_unfiltered_scenes_r1_1(tmpdir):
     ), f"Scene select failed. List of entries to process is not available - {matching_files}"
     ards_to_process = get_list_from_file(matching_files[0])
 
-    expected_files = get_expected_file_paths()
+    expected_files = get_expected_file_paths(DATASETS)
     assert Counter(ards_to_process) == Counter(
         expected_files
     ), "Lists do not have the same contents."

--- a/tests/integration_tests/test_scene_filtering_outside_AOI_r_2_3.py
+++ b/tests/integration_tests/test_scene_filtering_outside_AOI_r_2_3.py
@@ -50,10 +50,8 @@ DATASETS = [
     ),
 ]
 
-def get_expected_file_paths() -> List:
-    return [file_path.replace(".odc-metadata.yaml", ".tar") for file_path in DATASETS]
-
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
+
 
 def test_ard_landsat_scenes_outside_AOI_r2_3(tmp_path):
 

--- a/tests/integration_tests/test_scene_name_filtering_r_2_2.py
+++ b/tests/integration_tests/test_scene_name_filtering_r_2_2.py
@@ -50,10 +50,6 @@ DATASETS = [
 ]
 
 
-def get_expected_file_paths() -> List:
-    return [file_path.replace(".odc-metadata.yaml", ".tar") for file_path in DATASETS]
-
-
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 

--- a/tests/integration_tests/test_scene_no_ancillary_r_2_4.py
+++ b/tests/integration_tests/test_scene_no_ancillary_r_2_4.py
@@ -52,6 +52,7 @@ DATASETS = [
 
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
+
 def test_ard_landsat_scenes_no_acillary_r2_4(tmp_path):
 
     cmd_params = [

--- a/tests/integration_tests/test_scene_r_2_7.py
+++ b/tests/integration_tests/test_scene_r_2_7.py
@@ -1,6 +1,6 @@
 """
-    DSNS-235
-    R2.5 Filter within the excluded days
+    DSNS-236
+    R2.6 Filter out l1 scenes if the dataset has a child and the child is not archived
 """
 from pathlib import Path
 import os
@@ -44,14 +44,26 @@ DATASETS_DIR = (
 DATASETS = [
     os.path.join(
         DATASETS_DIR,
-        "c3/LC80920852020223_excluded_day/LC08_L1TP_092085_20200810_20200821_01_T1.odc-metadata.yaml",
+        "c3/LC80900742020304/LC08_L1GT_090074_20201030_20201106_01_T2.odc-metadata.yaml",
+    ),
+    os.path.join(
+        DATASETS_DIR,
+        "c3/ARD_LC80900742020304_final/ga_ls8c_ard_3-1-0_090074_2020-10-30_final.odc-metadata.yaml",
+    ),
+    os.path.join(
+        DATASETS_DIR,
+        "c3/LC80960702022336_do_interim/LC08_L1TP_096070_20221202_20221212_02_T1.odc-metadata.yaml",
+    ),
+    os.path.join(
+        DATASETS_DIR,
+        "c3/LC80960702022336_ard/ga_ls8c_ard_3-2-1_096070_2022-12-02_interim.odc-metadata.yaml",
     ),
 ]
 
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_scene_filtering_within_excluded_days_r_2_5(tmp_path):
+def test_scene_filtering_r_2_6(tmp_path):
     """
     This is the collective test that implements the requirement as
     defined at the top of this test suite.
@@ -64,8 +76,6 @@ def test_scene_filtering_within_excluded_days_r_2_5(tmp_path):
         '[ "usgs_ls8c_level1_1" ]',
         "--logdir",
         tmp_path,
-        "--days-to-exclude",
-        '["2009-01-03:2009-01-05"]',
     ]
 
     runner = CliRunner()
@@ -76,6 +86,39 @@ def test_scene_filtering_within_excluded_days_r_2_5(tmp_path):
 
     assert result.exit_code == 0, "The scene_select process failed to execute"
 
+    # Use glob to search for the log file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
+
+    # There's only ever 1 copy of this file
+    assert (
+        matching_files and matching_files[0] is not None
+    ), f"Scene select failed. Log is not available - {matching_files}"
+
+    assert matching_files and matching_files[0] is not None, (
+        "Scene select failed. List of entries to process is not available -",
+        f" {matching_files}",
+    )
+
+    found_log_line = False
+    with open(matching_files[0], encoding="utf-8") as ard_log_file:
+        for line in ard_log_file:
+            try:
+                jline = json.loads(line)
+                if (
+                    all(key in jline for key in ("reason", "dataset_id", "event"))
+                    and jline["reason"] == "The scene has been processed"
+                    and jline["dataset_id"] == "91f2fbd8-8ad5-550b-a62c-d819e1a4baaa"
+                    and jline["event"] == "scene removed"
+                ):
+                    found_log_line = True
+                    break
+            except json.JSONDecodeError as error_string:
+                print(f"Error decoding JSON: {error_string}")
+    assert (
+        found_log_line
+    ), "Landsat scene still selected despite its date is being excluded"
+
     # Use glob to search for the scenes_to_ARD_process.txt file
     # within filter-jobid-* directories
     matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
@@ -83,7 +126,7 @@ def test_scene_filtering_within_excluded_days_r_2_5(tmp_path):
     # There's only ever 1 copy of scenes_to_ARD_process.txt after
     # successfully processing
     assert matching_files and matching_files[0] is not None, (
-        "Scene select failed. List of entries to process is not available "
+        f"Scene select failed. List of entries to process is not available :{ODC_FILTERED_FILE} "
         f"- {matching_files}"
     )
     ards_to_process = get_list_from_file(matching_files[0])
@@ -95,26 +138,3 @@ def test_scene_filtering_within_excluded_days_r_2_5(tmp_path):
         "Ard entries to process exist when we are not expecting "
         f"anything to be there, {ards_to_process}"
     )
-
-    # Use glob to search for the log file
-    # within filter-jobid-* directories
-    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
-
-    # There's only ever 1 copy of this file
-    assert (
-        matching_files and matching_files[0] is not None
-    ), f"Scene select failed. Log is not available - {matching_files}"
-
-    found_log_line = False
-    with open(matching_files[0], encoding="utf-8") as ard_log_file:
-        for line in ard_log_file:
-            try:
-                jline = json.loads(line)
-                if "reason" in jline and jline["reason"] == "This day is excluded.":
-                    found_log_line = True
-                    break
-            except json.JSONDecodeError as error_string:
-                print(f"Error decoding JSON: {error_string}")
-    assert (
-        found_log_line
-    ), "Landsat scene still selected despite its date is being excluded"

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -21,3 +21,22 @@ def get_list_from_file(list_file: str) -> List:
         file_list = [line.strip() for line in file]
 
     return file_list
+
+
+"""
+    Generate a list of expected file paths by replacing
+    '.odc-metadata.yaml' with '.tar'
+    for each file path in a given list.
+
+    Parameter(s):
+    - List: A list of file paths containing '.odc-metadata.yaml' files.
+
+    Returns:
+    - List: A list of file paths with '.tar' extensions, corresponding
+        to the input DATASETS.
+
+"""
+
+
+def get_expected_file_paths(DATASETS: List) -> List:
+    return [file_path.replace(".odc-metadata.yaml", ".tar") for file_path in DATASETS]


### PR DESCRIPTION
 - Introduction of integration tests to test the processing of a scene given the ancillary is not there, after the wait timei (process to interim). This relates to R3.1 in db_index.sh
 - Maintenance: 1.Removed unused function in test_scene_filtering_outside_AOI_r_2_3.py and test_scene_name_filtering_r_2_2.py for accuracy 2.Refactored get_expected_file_paths to util