### PR TITLE
DSNS-229, 230 and 231

### DIFF
--- a/tests/integration_tests/db_index.sh
+++ b/tests/integration_tests/db_index.sh
@@ -24,7 +24,8 @@ if [[ $HOSTNAME == *"LAPTOP-UOJEO8EI"* ]]; then
     echo "duncans laptop"
     echo "conda activate odc2020"
 fi
-
+script_directory=$(dirname $(dirname "$(readlink -f "$0")"))
+TEST_DATA="$script_directory/test_data/integration_tests"
 
 # Defining S2 l1's
 datacube $ODCCONF metadata add https://raw.githubusercontent.com/GeoscienceAustralia/dea-config/master/product_metadata/eo3_sentinel.odc-type.yaml
@@ -69,8 +70,7 @@ datacube $ODCCONF product add https://raw.githubusercontent.com/GeoscienceAustra
 # R1.1 for ls: Unfiltered scenes are ARD processed
 # The tar is from /g/data/da82/AODH/USGS/L1/Landsat/C1/092_085/LC80920852020223
 
-script_directory=$(dirname $(dirname "$(readlink -f "$0")"))
-TEST_DATA="$script_directory/test_data/integration_tests"
+
 
 #datacube $ODCCONF dataset add --confirm-ignore-lineage $TEST_DATA/c3/LC80920852020223_good/LC08_L1TP_092085_20200810_20200821_01_T1.odc-metadata.yaml
 
@@ -250,7 +250,7 @@ datacube $ODCCONF dataset archive 760315b3-e147-5db2-bb7f-0e52efd4453d
 # The scene is filtered out since there is alread a child.
 
 # ---------------------
-
+datacube $ODCCONF dataset add   $TEST_DATA/s2/autogen/yaml/2022/2022-01/15S140E-20S145E/S2A_MSIL1C_20220124T004711_N0301_R102_T54LYH_20220124T021536.odc-metadata.yaml
 
 datacube  $ODCCONF product list # 
 ./check_db.sh

--- a/tests/integration_tests/launch_test.sh
+++ b/tests/integration_tests/launch_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This is a test launcher whereby we can give it any test 
+# This is a test launcher whereby we can give it any test
 # or *.py to run on pytest
 
 host=localhost
@@ -19,15 +19,19 @@ if [[ $HOSTNAME == *"gadi"* ]]; then
 
 fi
 
-export ODC_TEST_DB_URL=postgresql://$USER"@"$host"/"$USER"_automated_testing"
+#export the following so that the s2 tests can directly manipulate the
+# local datacube with regards to dataset
+export ODC_DB=$USER"_automated_testing"
+export ODC_TEST_DB_URL=postgresql://$USER"@"$host":"$port"/"$ODC_DB
+export ODC_HOST=$host
 
 if [[ $HOSTNAME == *"LAPTOP-UOJEO8EI"* ]]; then
   echo "duncans laptop"
   echo "conda activate /home/duncan/bin/miniconda3/envs/odc2020"
   echo "note the conda env is broken"
   echo "sudo service postgresql start"
-
 fi
+
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SSPATH=$DIR/../../
@@ -36,8 +40,8 @@ SSPATH=$DIR/../../
 #echo $PYTHONPATH
 export PYTHONPATH=$PYTHONPATH
 
-cd "$(dirname "$0")"
 
+cd "$(dirname "$0")"
 
 if [ -e $1 ]; then
   echo " Going to run $1"

--- a/tests/integration_tests/s2_go_select.sh
+++ b/tests/integration_tests/s2_go_select.sh
@@ -36,5 +36,16 @@ mkdir -p $pkgdir
 # ard processing
 # test DB index
 
-python3 $SSPATH/scene_select/ard_scene_select.py  --config ${USER}_dev.conf --products '["esa_s2am_level1_0"]' $yamdir  --workdir $scratch/  --pkgdir  $pkgdir --logdir $scratch/ --env $PWD/s2_interim_prod_wagl.env --project u46 --walltime 02:30:00  --interim-days-wait 5  --index-datacube-env index-test-odc.env # --run-ard
-
+python3 $SSPATH/scene_select/ard_scene_select.py \
+    --config ${USER}_dev.conf \
+    --products '["esa_s2am_level1_0"]' \
+    $yamdir \
+    --workdir $scratch/ \
+    --pkgdir $pkgdir \
+    --logdir $scratch/ \
+    --env $PWD/s2_interim_prod_wagl.env \
+    --project u46 \
+    --walltime 02:30:00 \
+    --interim-days-wait 5 \
+    --index-datacube-env index-test-odc.env \
+    # --run-ard

--- a/tests/integration_tests/test_s2_r1_1.py
+++ b/tests/integration_tests/test_s2_r1_1.py
@@ -1,0 +1,166 @@
+"""
+    DSNS-229 - R1.1 for s2: Unfiltered scenes are ARD processed
+"""
+from pathlib import Path
+from typing import List, Tuple
+import os
+import subprocess
+from click.testing import CliRunner
+import pytest
+from scene_select.ard_scene_select import scene_select, GEN_LOG_FILE
+from scene_select.do_ard import ODC_FILTERED_FILE
+
+from util import (
+    get_list_from_file,
+    generate_yamldir_value,
+    get_config_file_contents,
+)
+
+METADATA_DIR = (
+    Path(__file__).parent.joinpath("..", "test_data", "odc_setup", "metadata").resolve()
+)
+METADATA_TYPES = [
+    os.path.join(METADATA_DIR, "eo3_sentinel.odc-type.yaml"),
+    os.path.join(METADATA_DIR, "eo3_sentinel_ard.odc-type.yaml"),
+]
+
+PRODUCTS_DIR = (
+    Path(__file__).parent.joinpath("..", "test_data", "odc_setup", "eo3").resolve()
+)
+
+PRODUCTS = [
+    os.path.join(PRODUCTS_DIR, "esa_s2am_level1_0.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "ga_s2am_ard_3.odc-product.yaml"),
+]
+
+DATASETS_DIR = (
+    Path(__file__)
+    .parent.joinpath(
+        "..",
+        "test_data",
+        "integration_tests",
+    )
+    .resolve()
+)
+
+pytestmark = pytest.mark.usefixtures("auto_odc_db")
+
+dataset_paths = [
+    os.path.join(
+        DATASETS_DIR,
+        "s2/autogen/yaml/2022/2022-01/"
+        + "15S140E-20S145E/S2A_MSIL1C_20220124T004711_N0301_R102_T54LYH"
+        + "_20220124T021536.odc-metadata.yaml",
+    ),
+]
+
+
+def generate_commands_and_config_file_path(
+    paths: List[str], tmp_path
+) -> Tuple[str, str]:
+    """
+    Generate a group of shell commands that adds datasets to
+    the current datacube we are using to test.
+    This involves including environment variable settings
+    and dataset addition commands for each dataset path.
+    The reason this is done is because the s2 datasets
+    are not supported properly in pytest-odc at the
+    time this test is written.
+
+    Returns:
+        str: a long string comprising of multiple
+           shell commands as described above
+        str: the path to the config file
+
+        Note: the reason why this function is here
+        and not in utils.py is because some
+        dataset add commands in different upcoming
+        tests may not require "--confirm-ignore-lineage"
+        to be added
+    """
+
+    config_file_contents = get_config_file_contents()
+    test_config_file = os.path.abspath(tmp_path / "config_file.conf")
+
+    with open(test_config_file, "w", encoding="utf-8") as config_file_handler:
+        config_file_handler.write(config_file_contents)
+    config_file_handler.close()
+
+    datacube_add_command = ""
+    for dpath in paths:
+        datacube_add_command = (
+            datacube_add_command
+            + f"  datacube --config {test_config_file} "
+            + f" dataset add --confirm-ignore-lineage {dpath}; "
+        )
+
+    return datacube_add_command, test_config_file
+
+
+def test_s2_normal_operation_r1_1(tmp_path):
+    """
+    This is the collective test that implements the requirement as
+    defined at the top of this test suite.
+    """
+    datacube_add_commands, _ = generate_commands_and_config_file_path(
+        dataset_paths, tmp_path
+    )
+
+    # Run the command and capture its output
+    result = subprocess.run(
+        [datacube_add_commands],
+        shell=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    assert (
+        result.returncode == 0
+    ), f"The manual dataset addition failed: {result.stderr}"
+
+    yamldir = generate_yamldir_value()
+
+    cmd_params = [
+        "--products",
+        '[ "esa_s2am_level1_0" ]',
+        "--yamls-dir",
+        yamldir,
+        "--logdir",
+        tmp_path,
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        scene_select,
+        args=cmd_params,
+    )
+
+    assert (
+        result.exit_code == 0
+    ), f"The scene_select process failed to execute: {result.output}"
+    assert result.output != "", f" the result output is {result.output}"
+
+    # Use glob to search for the scenes_to_ARD_process.txt file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
+
+    # There's only ever 1 copy of scenes_to_ARD_process.txt after
+    # successfully processing
+    assert matching_files and matching_files[0] is not None, (
+        "Scene select failed. List of entries to process is not available : "
+        f"{ODC_FILTERED_FILE} - {matching_files}"
+    )
+
+    ards_to_process = get_list_from_file(matching_files[0])
+    assert (
+        len(ards_to_process) == 1
+    ), "Expected only 1 zip files to process but this has not been the case"
+
+    expected_file = (
+        "/g/data/u46/users/dsg547/test_data/c3/s2_autogen/zip/15S140E-20S145E"
+        + "/S2A_MSIL1C_20220124T004711_N0301_R102_T54LYH_20220124T021536.zip"
+    )
+
+    assert (
+        ards_to_process[0] == expected_file
+    ), "The generated ard file path is not what is expected"

--- a/tests/integration_tests/test_s2_r3_2.py
+++ b/tests/integration_tests/test_s2_r3_2.py
@@ -1,0 +1,178 @@
+"""
+    DSNS-230
+        R3.2 Process a scene if the child is interim and ancill data is there
+"""
+from pathlib import Path
+from typing import List, Tuple
+import os
+import subprocess
+from click.testing import CliRunner
+import pytest
+from scene_select.ard_scene_select import scene_select, GEN_LOG_FILE
+from scene_select.do_ard import ODC_FILTERED_FILE
+
+from util import (
+    get_list_from_file,
+    generate_yamldir_value,
+    get_config_file_contents,
+)
+
+METADATA_DIR = (
+    Path(__file__).parent.joinpath("..", "test_data", "odc_setup", "metadata").resolve()
+)
+METADATA_TYPES = [
+    os.path.join(METADATA_DIR, "eo3_sentinel.odc-type.yaml"),
+    os.path.join(METADATA_DIR, "eo3_sentinel_ard.odc-type.yaml"),
+]
+
+PRODUCTS_DIR = (
+    Path(__file__).parent.joinpath("..", "test_data", "odc_setup", "eo3").resolve()
+)
+
+PRODUCTS = [
+    os.path.join(PRODUCTS_DIR, "esa_s2am_level1_0.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "ga_s2am_ard_3.odc-product.yaml"),
+]
+
+DATASETS_DIR = (
+    Path(__file__)
+    .parent.joinpath(
+        "..",
+        "test_data",
+        "integration_tests",
+    )
+    .resolve()
+)
+
+pytestmark = pytest.mark.usefixtures("auto_odc_db")
+
+dataset_paths = [
+    os.path.join(
+        DATASETS_DIR,
+        "s2/autogen/yaml/2022/2022-11/30S130E-35S135E/"
+        + "S2A_MSIL1C_20221123T005711_N0400_R002_T53JMG_20221123T021932."
+        + "odc-metadata.yaml",
+    ),
+    os.path.join(
+        DATASETS_DIR,
+        "c3/S2A_MSIL1C_20221123T005711_N0400_R002_T53JMG_20221123T02193_ard/"
+        + "ga_s2am_ard_3-2-1_53JMG_2022-11-23_final.odc-metadata.yaml",
+    ),
+]
+
+
+def generate_commands_and_config_file_path(
+    paths: List[str], tmp_path
+) -> Tuple[str, str]:
+    """
+    Generate a group of shell commands that adds datasets to
+    the current datacube we are using to test.
+    This involves including environment variable settings
+    and dataset addition commands for each dataset path.
+    The reason this is done is because the s2 datasets
+    are not supported properly in pytest-odc at the
+    time this test is written.
+
+    Returns:
+        str: a long string comprising of multiple
+           shell commands as described above
+        str: the path to the config file
+
+        Note: the reason why this function is here
+            and not in utils.py is because some
+            dataset add commands in different upcoming
+            tests may not require "--confirm-ignore-lineage"
+            to be added
+
+    """
+
+    config_file_contents = get_config_file_contents()
+    test_config_file = os.path.abspath(tmp_path / "config_file.conf")
+
+    with open(test_config_file, "w", encoding="utf-8") as config_file_handler:
+        config_file_handler.write(config_file_contents)
+    config_file_handler.close()
+
+    datacube_add_command = ""
+    for dpath in paths:
+        datacube_add_command = (
+            datacube_add_command
+            + f"  datacube --config {test_config_file} "
+            + f" dataset add --confirm-ignore-lineage {dpath}; "
+        )
+
+    return datacube_add_command, test_config_file
+
+
+def test_s2_normal_operation_r3_2(tmp_path):
+    """
+    This is the collective test that implements the requirement as
+    defined at the top of this test suite.
+    """
+
+    datacube_add_commands, _ = generate_commands_and_config_file_path(
+        dataset_paths, tmp_path
+    )
+
+    # Run the command and capture its output
+    result = subprocess.run(
+        [datacube_add_commands],
+        shell=True,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    assert (
+        result.returncode == 0
+    ), f"The manual dataset addition failed: {result.stderr}"
+
+    yamldir = generate_yamldir_value()
+    cmd_params = [
+        "--products",
+        '[ "esa_s2am_level1_0" ]',
+        "--yamls-dir",
+        yamldir,
+        "--logdir",
+        tmp_path,
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        scene_select,
+        args=cmd_params,
+    )
+
+    assert (
+        result.exit_code == 0
+    ), f"The scene_select process failed to execute: {result.output}"
+    assert result.output != "", f" the result output is {result.output}"
+
+    # Use glob to search for the log file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
+
+    # Use glob to search for the scenes_to_ARD_process.txt file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
+
+    # There's only ever 1 copy of scenes_to_ARD_process.txt after
+    # successfully processing
+    assert matching_files and matching_files[0] is not None, (
+        "Scene select failed. List of entries to process is not available : "
+        f"{ODC_FILTERED_FILE} - {matching_files}"
+    )
+
+    ards_to_process = get_list_from_file(matching_files[0])
+    assert (
+        len(ards_to_process) == 1
+    ), "Expected only 1 zip files to process but this has not been the case"
+
+    expected_file = (
+        "/g/data/fj7/Copernicus/Sentinel-2/MSI/L1C/2022"
+        + "/2022-11/30S130E-35S135E"
+        + "/S2A_MSIL1C_20221123T005711_N0400_R002_T53JMG_20221123T021932.zip"
+    )
+
+    assert (
+        ards_to_process[0] == expected_file
+    ), "The generated ard file path is not what is expected"

--- a/tests/integration_tests/test_s2_r3_2.py
+++ b/tests/integration_tests/test_s2_r3_2.py
@@ -147,10 +147,6 @@ def test_s2_normal_operation_r3_2(tmp_path):
     ), f"The scene_select process failed to execute: {result.output}"
     assert result.output != "", f" the result output is {result.output}"
 
-    # Use glob to search for the log file
-    # within filter-jobid-* directories
-    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
-
     # Use glob to search for the scenes_to_ARD_process.txt file
     # within filter-jobid-* directories
     matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))

--- a/tests/integration_tests/test_scene_r_3_3.py
+++ b/tests/integration_tests/test_scene_r_3_3.py
@@ -1,6 +1,7 @@
 """
-    DSNS-236
-    R2.6 Filter out l1 scenes if the dataset has a child and the child is not archived
+    DSNS-231
+       R3.3 Filter out the l1 scene if there is already an ARD scene with the
+       same scene_id, that is un-archived.
 """
 from pathlib import Path
 import os
@@ -9,9 +10,10 @@ from click.testing import CliRunner
 import pytest
 from scene_select.ard_scene_select import scene_select, GEN_LOG_FILE
 from scene_select.do_ard import ODC_FILTERED_FILE
-
+import datacube
 from util import (
     get_list_from_file,
+    get_config_file_contents,
 )
 
 METADATA_DIR = (
@@ -28,7 +30,6 @@ PRODUCTS_DIR = (
 
 PRODUCTS = [
     os.path.join(PRODUCTS_DIR, "l1_ls8.odc-product.yaml"),
-    os.path.join(PRODUCTS_DIR, "l1_ls8_c2.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
 ]
 
@@ -44,33 +45,36 @@ DATASETS_DIR = (
 DATASETS = [
     os.path.join(
         DATASETS_DIR,
-        "c3/LC80900742020304/LC08_L1GT_090074_20201030_20201106_01_T2.odc-metadata.yaml",
+        "c3/LC81150802019349/LC08_L1TP_115080_20191215_20191226_01_T1.odc-metadata.yaml",
     ),
     os.path.join(
         DATASETS_DIR,
-        "c3/ARD_LC80900742020304_final/ga_ls8c_ard_3-1-0_090074_2020-10-30_final.odc-metadata.yaml",
+        "c3/LC81150802019349/LC08_L1TP_115080_20191215_20201023_01_T1.odc-metadata.yaml",
     ),
     os.path.join(
         DATASETS_DIR,
-        "c3/LC80960702022336_do_interim/LC08_L1TP_096070_20221202_20221212_02_T1.odc-metadata.yaml",
-    ),
-    os.path.join(
-        DATASETS_DIR,
-        "c3/LC80960702022336_ard/ga_ls8c_ard_3-2-1_096070_2022-12-02_interim.odc-metadata.yaml",
+        "c3/ARD_LC81150802019349_old/ga_ls8c_ard_3-1-0_115080_2019-12-15_final.odc-metadata.yaml",
     ),
 ]
 
+def generate_temp_config_file(tmp_path):
+    test_config_file = os.path.abspath(tmp_path / "config_file.conf")
+    config_file_contents = get_config_file_contents()
+    with open(test_config_file, "w", encoding="utf-8") as config_file_handler:
+        config_file_handler.write(config_file_contents)
+    config_file_handler.close()
+    return test_config_file
+
+
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
-
-def test_scene_filtering_r_2_6(tmp_path):
+def test_scene_r_3_3(odc_test_db: datacube.Datacube, tmp_path):
     """
     This is the collective test that implements the requirement as
     defined at the top of this test suite.
     """
+    odc_test_db.index.datasets.archive(["760315b3-e147-5db2-bb7f-0e52efd4453d"])
 
-    # Observe that there is a date exclusion filter passed
-    # into the process
     cmd_params = [
         "--products",
         '[ "usgs_ls8c_level1_1" ]',
@@ -86,6 +90,26 @@ def test_scene_filtering_r_2_6(tmp_path):
 
     assert result.exit_code == 0, "The scene_select process failed to execute"
 
+    # Use glob to search for the scenes_to_ARD_process.txt file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
+
+    # There's only ever 1 copy of scenes_to_ARD_process.txt after
+    # successfully processing
+    assert matching_files and matching_files[0] is not None, (
+        "Scene select failed. List of entries to process is not available - ",
+        f"{matching_files}",
+    )
+    ards_to_process = get_list_from_file(matching_files[0])
+
+    # Given that the run should have no ards to process, we expect
+    # an empty scenes_to_ARD_process.txt file.
+
+    assert len(ards_to_process) == 0, (
+        "Ard entries to process exist when we are not expecting anything",
+        " to be there",
+    )
+
     # Use glob to search for the log file
     # within filter-jobid-* directories
     matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
@@ -95,46 +119,25 @@ def test_scene_filtering_r_2_6(tmp_path):
         matching_files and matching_files[0] is not None
     ), f"Scene select failed. Log is not available - {matching_files}"
 
-    assert matching_files and matching_files[0] is not None, (
-        "Scene select failed. List of entries to process is not available -",
-        f" {matching_files}",
-    )
-
     found_log_line = False
+
     with open(matching_files[0], encoding="utf-8") as ard_log_file:
         for line in ard_log_file:
             try:
                 jline = json.loads(line)
                 if (
-                    all(key in jline for key in ("reason", "dataset_id", "event"))
+                    all(key in jline for key in ("reason", "event", "landsat_scene_id"))
                     and jline["reason"] == "The scene has been processed"
-                    and jline["dataset_id"] == "91f2fbd8-8ad5-550b-a62c-d819e1a4baaa"
                     and jline["event"] == "scene removed"
+                    and jline["landsat_scene_id"]
+                    == "LC08_L1TP_115080_20191215_20201023_01_T1"
                 ):
                     found_log_line = True
                     break
             except json.JSONDecodeError as error_string:
                 print(f"Error decoding JSON: {error_string}")
-    assert (
-        found_log_line
-    ), "Landsat scene still selected despite its date is being excluded"
 
-    # Use glob to search for the scenes_to_ARD_process.txt file
-    # within filter-jobid-* directories
-    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
-
-    # There's only ever 1 copy of scenes_to_ARD_process.txt after
-    # successfully processing
-    assert matching_files and matching_files[0] is not None, (
-        f"Scene select failed. List of entries to process is not available :{ODC_FILTERED_FILE} "
-        f"- {matching_files}"
-    )
-    ards_to_process = get_list_from_file(matching_files[0])
-
-    # Given that the run should have no ards to process, we expect
-    # an empty scenes_to_ARD_process.txt file.
-
-    assert len(ards_to_process) == 0, (
-        "Ard entries to process exist when we are not expecting "
-        f"anything to be there, {ards_to_process}"
+    assert found_log_line, (
+        "landsat scene still selected despite there is already an ARD scene",
+        " with the same id and its initial scene had been archived",
     )

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -2,7 +2,8 @@
     Helper functions for integration tests
 """
 
-from typing import List
+from typing import List, Optional
+import os
 
 
 def get_list_from_file(list_file: str) -> List:
@@ -40,3 +41,30 @@ def get_list_from_file(list_file: str) -> List:
 
 def get_expected_file_paths(DATASETS: List) -> List:
     return [file_path.replace(".odc-metadata.yaml", ".tar") for file_path in DATASETS]
+
+
+def generate_yamldir_value():
+    """
+    Generate the path to the YAML directory based on the script directory.
+
+    Returns:
+        str: A string representing the YAML directory path.
+    """
+
+    script_directory = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    return f" {os.path.join(script_directory, 'test_data/integration_tests/s2/autogen/yaml')}"
+
+
+def get_config_file_contents():
+    """
+    Create the temporary config file so that ard scene select
+    processes that get runned in this script as subprocesses
+    will be able to access the same datacube instance"""
+
+    user_id = os.getenv("USER")
+    return f"""
+[datacube]
+db_hostname: deadev.nci.org.au
+db_port: 5432
+db_database: {user_id}_automated_testing
+"""

--- a/tests/test_data/odc_setup/eo3/esa_s2am_level1_0.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/esa_s2am_level1_0.odc-product.yaml
@@ -1,0 +1,72 @@
+---
+name: esa_s2am_level1_0
+description: ESA Sentinel 2A Level 0
+metadata_type: eo3_sentinel
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: esa_s2am_level1_0
+  properties:
+     eo:platform: sentinel-2a
+     eo:instrument: MSI
+     odc:product_family: level1
+     odc:producer: esa.int
+
+measurements:
+  - name: blue
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: coastal_aerosol
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: green
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: nir_1
+    dtype: uint16
+    nodata: 0
+    units: '1'
+
+  - name: nir_2
+    dtype: uint16
+    nodata: 0
+    units: '1'
+
+  - name: red
+    dtype: uint16
+    nodata: 0
+    units: '1'
+
+  - name: red_edge_1
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: red_edge_2
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: red_edge_3
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_1_cirrus
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_2
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_3
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: water_vapour
+    dtype: uint16
+    nodata: 0
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/esa_s2bm_level1_0.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/esa_s2bm_level1_0.odc-product.yaml
@@ -1,0 +1,72 @@
+---
+name: esa_s2bm_level1_0
+description: ESA Sentinel 2B Level 0
+metadata_type: eo3_sentinel
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: esa_s2bm_level1_0
+  properties:
+     eo:platform: sentinel-2b
+     eo:instrument: MSI
+     odc:product_family: level1
+     odc:producer: esa.int
+
+measurements:
+  - name: blue
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: coastal_aerosol
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: green
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: nir_1
+    dtype: uint16
+    nodata: 0
+    units: '1'
+
+  - name: nir_2
+    dtype: uint16
+    nodata: 0
+    units: '1'
+
+  - name: red
+    dtype: uint16
+    nodata: 0
+    units: '1'
+
+  - name: red_edge_1
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: red_edge_2
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: red_edge_3
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_1_cirrus
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_2
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: swir_3
+    dtype: uint16
+    nodata: 0
+    units: '1'
+  - name: water_vapour
+    dtype: uint16
+    nodata: 0
+    units: '1'

--- a/tests/test_data/odc_setup/eo3/ga_s2am_ard_3.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/ga_s2am_ard_3.odc-product.yaml
@@ -1,0 +1,233 @@
+---
+name: ga_s2am_ard_3
+description: Geoscience Australia Sentinel 2A MSI Analysis Ready Data Collection 3
+metadata_type: eo3_sentinel_ard
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ga_s2am_ard_3
+  properties:
+     eo:platform: sentinel-2a
+     eo:instrument: MSI
+     odc:product_family: ard
+     odc:producer: ga.gov.au
+     dea:product_maturity: stable
+
+measurements:
+    # NBART
+  - name: nbart_coastal_aerosol
+    aliases:
+      - nbart_band01
+      - coastal_aerosol
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_blue
+    aliases:
+      - nbart_band02
+      - blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_green
+    aliases:
+      - nbart_band03
+      - green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red
+    aliases:
+      - nbart_band04
+      - red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red_edge_1
+    aliases:
+      - nbart_band05
+      - red_edge_1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red_edge_2
+    aliases:
+      - nbart_band06
+      - red_edge_2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red_edge_3
+    aliases:
+      - nbart_band07
+      - red_edge_3
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir_1
+    aliases:
+      - nbart_band08
+      - nir_1
+      - nbart_common_nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir_2
+    aliases:
+      - nbart_band8a
+      - nir_2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_2
+    aliases:
+      - nbart_band11
+      - swir_2
+      - nbart_common_swir_1
+      # Requested for backwards compatibility with previous collection
+      - swir2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_3
+    aliases:
+      - nbart_band12
+      - swir_3
+      - nbart_common_swir_2
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # Observation Attributes
+  - name: oa_fmask
+    aliases:
+      - fmask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      fmask:
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
+        description: Fmask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+          '3': shadow
+          '4': snow
+          '5': water
+  - name: oa_nbart_contiguity
+    aliases:
+      - nbart_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_azimuthal_exiting
+    aliases:
+      - azimuthal_exiting
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_azimuthal_incident
+    aliases:
+      - azimuthal_incident
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_combined_terrain_shadow
+    aliases:
+      - combined_terrain_shadow
+    dtype: uint8
+    nodata: 255
+    units: '1'
+  - name: oa_exiting_angle
+    aliases:
+      - exiting_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_incident_angle
+    aliases:
+      - incident_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_azimuth
+    aliases:
+      - relative_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_slope
+    aliases:
+      - relative_slope
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_azimuth
+    aliases:
+      - satellite_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_view
+    aliases:
+      - satellite_view
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_azimuth
+    aliases:
+      - solar_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_zenith
+    aliases:
+      - solar_zenith
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_time_delta
+    aliases:
+      - time_delta
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_s2cloudless_mask
+    aliases:
+      - s2cloudless_mask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      s2cloudless_mask:
+        bits: [0, 1, 2]
+        description: s2cloudless mask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+  - name: oa_s2cloudless_prob
+    aliases:
+      - s2cloudless_prob
+    dtype: float64
+    nodata: .nan
+    units: '1'
+
+load:
+  crs: 'EPSG:3577'
+  resolution:
+    y: -10
+    x: 10
+  align:
+    y: 0
+    x: 0

--- a/tests/test_data/odc_setup/eo3/ga_s2bm_ard_3.odc-product.yaml
+++ b/tests/test_data/odc_setup/eo3/ga_s2bm_ard_3.odc-product.yaml
@@ -1,0 +1,233 @@
+---
+name: ga_s2bm_ard_3
+description: Geoscience Australia Sentinel 2B MSI Analysis Ready Data Collection 3
+metadata_type: eo3_sentinel_ard
+
+license: CC-BY-4.0
+
+metadata:
+  product:
+    name: ga_s2bm_ard_3
+  properties:
+     eo:platform: sentinel-2b
+     eo:instrument: MSI
+     odc:product_family: ard
+     odc:producer: ga.gov.au
+     dea:product_maturity: stable
+
+measurements:
+    # NBART
+  - name: nbart_coastal_aerosol
+    aliases:
+      - nbart_band01
+      - coastal_aerosol
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_blue
+    aliases:
+      - nbart_band02
+      - blue
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_green
+    aliases:
+      - nbart_band03
+      - green
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red
+    aliases:
+      - nbart_band04
+      - red
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red_edge_1
+    aliases:
+      - nbart_band05
+      - red_edge_1
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red_edge_2
+    aliases:
+      - nbart_band06
+      - red_edge_2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_red_edge_3
+    aliases:
+      - nbart_band07
+      - red_edge_3
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir_1
+    aliases:
+      - nbart_band08
+      - nir_1
+      - nbart_common_nir
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_nir_2
+    aliases:
+      - nbart_band8a
+      - nir_2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_2
+    aliases:
+      - nbart_band11
+      - swir_2
+      - nbart_common_swir_1
+      # Requested for backwards compatibility with previous collection
+      - swir2
+    dtype: int16
+    nodata: -999
+    units: '1'
+  - name: nbart_swir_3
+    aliases:
+      - nbart_band12
+      - swir_3
+      - nbart_common_swir_2
+    dtype: int16
+    nodata: -999
+    units: '1'
+
+    # Observation Attributes
+  - name: oa_fmask
+    aliases:
+      - fmask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      fmask:
+        bits: [0, 1, 2, 3, 4, 5, 6, 7]
+        description: Fmask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+          '3': shadow
+          '4': snow
+          '5': water
+  - name: oa_nbart_contiguity
+    aliases:
+      - nbart_contiguity
+    dtype: uint8
+    nodata: 255
+    units: '1'
+    flags_definition:
+      contiguous:
+        bits: [0]
+        values:
+          '1': true
+          '0': false
+  - name: oa_azimuthal_exiting
+    aliases:
+      - azimuthal_exiting
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_azimuthal_incident
+    aliases:
+      - azimuthal_incident
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_combined_terrain_shadow
+    aliases:
+      - combined_terrain_shadow
+    dtype: uint8
+    nodata: 255
+    units: '1'
+  - name: oa_exiting_angle
+    aliases:
+      - exiting_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_incident_angle
+    aliases:
+      - incident_angle
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_azimuth
+    aliases:
+      - relative_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_relative_slope
+    aliases:
+      - relative_slope
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_azimuth
+    aliases:
+      - satellite_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_satellite_view
+    aliases:
+      - satellite_view
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_azimuth
+    aliases:
+      - solar_azimuth
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_solar_zenith
+    aliases:
+      - solar_zenith
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_time_delta
+    aliases:
+      - time_delta
+    dtype: float32
+    nodata: .nan
+    units: '1'
+  - name: oa_s2cloudless_mask
+    aliases:
+      - s2cloudless_mask
+    dtype: uint8
+    nodata: 0
+    units: '1'
+    flags_definition:
+      s2cloudless_mask:
+        bits: [0, 1, 2]
+        description: s2cloudless mask
+        values:
+          '0': nodata
+          '1': valid
+          '2': cloud
+  - name: oa_s2cloudless_prob
+    aliases:
+      - s2cloudless_prob
+    dtype: float64
+    nodata: .nan
+    units: '1'
+
+load:
+  crs: 'EPSG:3577'
+  resolution:
+    y: -10
+    x: 10
+  align:
+    y: 0
+    x: 0


### PR DESCRIPTION

    DSNS-231:
        - Introduced integration tests for landset l1 data - R3.3 Filter out
          the l1 scene if there is already an ARD scene with the same scene_id,
          that is un-archived
    DSNS-230:
        1. Introduced new integration tests for s2 data - R3.2 Process a scene
           if the child is interim and ancill data is there
        2. Updated util.py's get_extracted_path() to work with s2. Also tested
           the existing tests to ensure they still work.
    DSNS-229:
        - Introduced new integration tests for s2 data - R1.1 Unfiltered scenes
        are ARD processed