### PR TITLE
DSNS-262:  pytest-odc packaging into scene select

### DIFF
--- a/modules/package-module.sh
+++ b/modules/package-module.sh
@@ -89,8 +89,11 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
 	if [[ $2 == "--prod" ]]; then
 		installrepo ard-scene-select module-prod https://github.com/GeoscienceAustralia/dea-ard-scene-select.git
 	else
-		installrepo ard-scene-select  dsg_dev    https://github.com/GeoscienceAustralia/dea-ard-scene-select.git
+		echo "Non prod..."
+		installrepo ard-scene-select  master    https://github.com/GeoscienceAustralia/dea-ard-scene-select.git
 	fi
+        echo "Installing pytest-odc..."
+        installrepo pytest-odc main https://github.com/opendatacube/pytest-odc
 	
 	echo
 	echo "Writing modulefile"


### PR DESCRIPTION
Packaged pytest-odc into dea-scene-select module so that  
 regression tests can be run without having to install the pytest-odc
    module separately. Not only would this be convenient, it would that the
    revision of the pytest-odc module is controlled for consistency.