### PR TITLE
DSNS-240:

### DIFF
--- a/tests/integration_tests/db_index.sh
+++ b/tests/integration_tests/db_index.sh
@@ -119,7 +119,7 @@ datacube $ODCCONF dataset add --confirm-ignore-lineage $TEST_DATA/c3/LC809208520
 
 # ---------------------
 # ---------------------
-#R2.6 Filter out l1 scenes if the dataset has a child and the child is not archived 
+#R2.6.1 Filter out l1 scenes if the dataset has a child and the child is not archived DSNS 236
 #
 # Add an L1 scene
 # id: 91f2fbd8-8ad5-550b-a62c-d819e1a4baaa
@@ -136,7 +136,8 @@ datacube $ODCCONF dataset add --confirm-ignore-lineage  $TEST_DATA/c3/ARD_LC8090
 
 # ---------------------
 # ---------------------
-#R2.6 Filter out ls8 l1 scenes if the dataset has a child, the child is interim and there is no ancillary 
+#R2.8.1 Filter out ls8 l1 scenes if the dataset has a child,
+# the child is interim and there is no ancillary - DSNS 237
 #
 # Add an L1 scene
 # id: 768675cd-0c2b-5a17-871a-1f35eabac78e
@@ -150,7 +151,7 @@ datacube $ODCCONF dataset add --confirm-ignore-lineage  $TEST_DATA/c3/LC80960702
 # Filter Outcome- scene not selected to process - ls_go_select
 # ---------------------
 # ---------------------
-#R2.6 Filter out S2 l1 scenes if the dataset has a child, the child is interim and there is no ancillary 
+#R2.8.2 Filter out S2 l1 scenes if the dataset has a child,   -DSNS 240
 #
 # Add an L1 scene
 # id: 6a446ae9-7b10-544f-837b-c55b65ec7d68

--- a/tests/integration_tests/test_interim_prod_r3_1.py
+++ b/tests/integration_tests/test_interim_prod_r3_1.py
@@ -1,0 +1,134 @@
+"""
+    DSNS-239
+    R3.1 Process a scene if the ancillary is not there,
+    after the wait time (Process to interim)
+"""
+from collections import Counter
+from pathlib import Path
+import os
+import json
+from click.testing import CliRunner
+import pytest
+from scene_select.ard_scene_select import scene_select, GEN_LOG_FILE
+from scene_select.do_ard import ODC_FILTERED_FILE
+
+from util import (
+    get_list_from_file,
+    get_expected_file_paths,
+)
+
+METADATA_DIR = (
+    Path(__file__).parent.joinpath("..", "test_data", "odc_setup", "metadata").resolve()
+)
+METADATA_TYPES = [
+    os.path.join(METADATA_DIR, "eo3_landsat_l1.odc-type.yaml"),
+    os.path.join(METADATA_DIR, "eo3_landsat_ard.odc-type.yaml"),
+]
+
+PRODUCTS_DIR = (
+    Path(__file__).parent.joinpath("..", "test_data", "odc_setup", "eo3").resolve()
+)
+
+PRODUCTS = [
+    os.path.join(PRODUCTS_DIR, "l1_ls8.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "l1_ls8_c2.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
+]
+
+DATASETS_DIR = (
+    Path(__file__)
+    .parent.joinpath(
+        "..",
+        "test_data",
+        "integration_tests",
+    )
+    .resolve()
+)
+DATASETS = [
+    os.path.join(
+        DATASETS_DIR,
+        "c3/LC81020792023029_do_interim/LC08_L1GT_102079_20230129_20230227_02_T2.odc-metadata.yaml",
+    ),
+]
+
+pytestmark = pytest.mark.usefixtures("auto_odc_db")
+
+
+def test_interim_prod_r3_1(tmp_path):
+    """
+    This is the collective test that implements the requirement as
+    defined at the top of this test suite.
+    """
+
+    # Observe that there is a date exclusion filter passed
+    # into the process
+    cmd_params = [
+        "--products",
+        '[ "usgs_ls8c_level1_2" ]',
+        "--logdir",
+        tmp_path,
+        "--allowed-codes",
+        "Australian_AOI_107069_added.json",
+        "--days-to-exclude",
+        '["2009-01-03:2009-01-05"]',
+        "--interim-days-wait",
+        5,
+    ]
+
+    runner = CliRunner()
+    result = runner.invoke(
+        scene_select,
+        args=cmd_params,
+    )
+
+    assert result.exit_code == 0, "The scene_select process failed to execute"
+
+    # Use glob to search for the log file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
+
+    # There's only ever 1 copy of this file
+    assert (
+        matching_files and matching_files[0] is not None
+    ), f"Scene select failed. Log is not available - {matching_files}"
+
+    assert matching_files and matching_files[0] is not None, (
+        "Scene select failed. List of entries to process is not available -",
+        f" {matching_files}",
+    )
+
+    found_log_line = False
+    with open(matching_files[0], encoding="utf-8") as ard_log_file:
+        for line in ard_log_file:
+            try:
+                jline = json.loads(line)
+                if (
+                    all(key in jline for key in ("event", "landsat_scene_id", "level"))
+                    and jline["event"] == "No ancillary. Processing to interim"
+                    and jline["landsat_scene_id"]
+                    == "LC08_L1GT_102079_20230129_20230227_02_T2"
+                    and jline["level"] == "debug"
+                ):
+                    found_log_line = True
+                    break
+            except json.JSONDecodeError as error_string:
+                print(f"Error decoding JSON: {error_string}")
+    assert (
+        found_log_line
+    ), "Landsat scene still selected despite its date is being excluded"
+
+    # Use glob to search for the scenes_to_ARD_process.txt file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
+
+    # There's only ever 1 copy of scenes_to_ARD_process.txt after
+    # successfully processing
+    assert matching_files and matching_files[0] is not None, (
+        f"Scene select failed. List of entries to process is not available :{ODC_FILTERED_FILE} "
+        f"- {matching_files}"
+    )
+    ards_to_process = get_list_from_file(matching_files[0])
+    expected_files = get_expected_file_paths(DATASETS)
+    assert Counter(ards_to_process) == Counter(
+        expected_files
+    ), "Lists do not have the same contents."

--- a/tests/integration_tests/test_s2_r1_1.py
+++ b/tests/integration_tests/test_s2_r1_1.py
@@ -1,5 +1,6 @@
 """
-    DSNS-229 - R1.1 for s2: Unfiltered scenes are ARD processed
+    DSNS-229
+        R1.1 for s2: Unfiltered scenes are ARD processed
 """
 from pathlib import Path
 from typing import List, Tuple

--- a/tests/integration_tests/test_s2_r2_8_2.py
+++ b/tests/integration_tests/test_s2_r2_8_2.py
@@ -4,8 +4,6 @@
         the child is interim and there is no ancillary
 """
 
-# TODO - Still failing
-
 from pathlib import Path
 from typing import List, Tuple
 import os

--- a/tests/integration_tests/test_s2_r2_8_2.py
+++ b/tests/integration_tests/test_s2_r2_8_2.py
@@ -1,8 +1,11 @@
 """
-    DSNS-238
-    R2.8 Filter out S2 l1 scenes if the dataset has a child,
-    the child is interim and there is no ancillary
+    DSNS-240
+        R2.8.2 Filter out S2 l1 scenes if the dataset has a child,
+        the child is interim and there is no ancillary
 """
+
+# TODO - Still failing
+
 from pathlib import Path
 from typing import List, Tuple
 import os
@@ -114,7 +117,7 @@ def generate_commands_and_config_file_path(
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_scene_filtering_r_2_6(tmp_path):
+def test_scene_filtering_r2_8_2(tmp_path):
     """
     This is the collective test that implements the requirement as
     defined at the top of this test suite.

--- a/tests/integration_tests/test_scene_r2_6_1.py
+++ b/tests/integration_tests/test_scene_r2_6_1.py
@@ -1,7 +1,7 @@
 """
-    DSNS-231
-       R3.3 Filter out the l1 scene if there is already an ARD scene with the
-       same scene_id, that is un-archived.
+    DSNS-236
+        R2.6.1 Filter out l1 scenes if the dataset has a child
+        and the child is not archived
 """
 from pathlib import Path
 import os
@@ -10,10 +10,9 @@ from click.testing import CliRunner
 import pytest
 from scene_select.ard_scene_select import scene_select, GEN_LOG_FILE
 from scene_select.do_ard import ODC_FILTERED_FILE
-import datacube
+
 from util import (
     get_list_from_file,
-    get_config_file_contents,
 )
 
 METADATA_DIR = (
@@ -30,6 +29,7 @@ PRODUCTS_DIR = (
 
 PRODUCTS = [
     os.path.join(PRODUCTS_DIR, "l1_ls8.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "l1_ls8_c2.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
 ]
 
@@ -45,36 +45,25 @@ DATASETS_DIR = (
 DATASETS = [
     os.path.join(
         DATASETS_DIR,
-        "c3/LC81150802019349/LC08_L1TP_115080_20191215_20191226_01_T1.odc-metadata.yaml",
+        "c3/LC80900742020304/LC08_L1GT_090074_20201030_20201106_01_T2.odc-metadata.yaml",
     ),
     os.path.join(
         DATASETS_DIR,
-        "c3/LC81150802019349/LC08_L1TP_115080_20191215_20201023_01_T1.odc-metadata.yaml",
-    ),
-    os.path.join(
-        DATASETS_DIR,
-        "c3/ARD_LC81150802019349_old/ga_ls8c_ard_3-1-0_115080_2019-12-15_final.odc-metadata.yaml",
+        "c3/ARD_LC80900742020304_final/ga_ls8c_ard_3-1-0_090074_2020-10-30_final.odc-metadata.yaml",
     ),
 ]
 
-def generate_temp_config_file(tmp_path):
-    test_config_file = os.path.abspath(tmp_path / "config_file.conf")
-    config_file_contents = get_config_file_contents()
-    with open(test_config_file, "w", encoding="utf-8") as config_file_handler:
-        config_file_handler.write(config_file_contents)
-    config_file_handler.close()
-    return test_config_file
-
-
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
-def test_scene_r_3_3(odc_test_db: datacube.Datacube, tmp_path):
+
+def test_scene_filtering_r2_6_1(tmp_path):
     """
     This is the collective test that implements the requirement as
     defined at the top of this test suite.
     """
-    odc_test_db.index.datasets.archive(["760315b3-e147-5db2-bb7f-0e52efd4453d"])
 
+    # Observe that there is a date exclusion filter passed
+    # into the process
     cmd_params = [
         "--products",
         '[ "usgs_ls8c_level1_1" ]',
@@ -90,26 +79,6 @@ def test_scene_r_3_3(odc_test_db: datacube.Datacube, tmp_path):
 
     assert result.exit_code == 0, "The scene_select process failed to execute"
 
-    # Use glob to search for the scenes_to_ARD_process.txt file
-    # within filter-jobid-* directories
-    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
-
-    # There's only ever 1 copy of scenes_to_ARD_process.txt after
-    # successfully processing
-    assert matching_files and matching_files[0] is not None, (
-        "Scene select failed. List of entries to process is not available - ",
-        f"{matching_files}",
-    )
-    ards_to_process = get_list_from_file(matching_files[0])
-
-    # Given that the run should have no ards to process, we expect
-    # an empty scenes_to_ARD_process.txt file.
-
-    assert len(ards_to_process) == 0, (
-        "Ard entries to process exist when we are not expecting anything",
-        " to be there",
-    )
-
     # Use glob to search for the log file
     # within filter-jobid-* directories
     matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
@@ -119,25 +88,46 @@ def test_scene_r_3_3(odc_test_db: datacube.Datacube, tmp_path):
         matching_files and matching_files[0] is not None
     ), f"Scene select failed. Log is not available - {matching_files}"
 
-    found_log_line = False
+    assert matching_files and matching_files[0] is not None, (
+        "Scene select failed. List of entries to process is not available -",
+        f" {matching_files}",
+    )
 
+    found_log_line = False
     with open(matching_files[0], encoding="utf-8") as ard_log_file:
         for line in ard_log_file:
             try:
                 jline = json.loads(line)
                 if (
-                    all(key in jline for key in ("reason", "event", "landsat_scene_id"))
+                    all(key in jline for key in ("reason", "dataset_id", "event"))
                     and jline["reason"] == "The scene has been processed"
+                    and jline["dataset_id"] == "91f2fbd8-8ad5-550b-a62c-d819e1a4baaa"
                     and jline["event"] == "scene removed"
-                    and jline["landsat_scene_id"]
-                    == "LC08_L1TP_115080_20191215_20201023_01_T1"
                 ):
                     found_log_line = True
                     break
             except json.JSONDecodeError as error_string:
                 print(f"Error decoding JSON: {error_string}")
+    assert (
+        found_log_line
+    ), "Landsat scene still selected despite its date is being excluded"
 
-    assert found_log_line, (
-        "landsat scene still selected despite there is already an ARD scene",
-        " with the same id and its initial scene had been archived",
+    # Use glob to search for the scenes_to_ARD_process.txt file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
+
+    # There's only ever 1 copy of scenes_to_ARD_process.txt after
+    # successfully processing
+    assert matching_files and matching_files[0] is not None, (
+        f"Scene select failed. List of entries to process is not available :{ODC_FILTERED_FILE} "
+        f"- {matching_files}"
+    )
+    ards_to_process = get_list_from_file(matching_files[0])
+
+    # Given that the run should have no ards to process, we expect
+    # an empty scenes_to_ARD_process.txt file.
+
+    assert len(ards_to_process) == 0, (
+        "Ard entries to process exist when we are not expecting "
+        f"anything to be there, {ards_to_process}"
     )

--- a/tests/integration_tests/test_scene_r2_8_1.py
+++ b/tests/integration_tests/test_scene_r2_8_1.py
@@ -29,14 +29,10 @@ PRODUCTS_DIR = (
 )
 
 PRODUCTS = [
-    os.path.join(PRODUCTS_DIR, "l1_ls7.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "l1_ls8.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "l1_ls8_c2.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
-    os.path.join(PRODUCTS_DIR, "l1_ls9.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
-    os.path.join(PRODUCTS_DIR, "ard_ls7.odc-product.yaml"),
-    os.path.join(PRODUCTS_DIR, "ard_ls9.odc-product.yaml"),
 ]
 
 DATASETS_DIR = (

--- a/tests/integration_tests/test_scene_r2_8_1.py
+++ b/tests/integration_tests/test_scene_r2_8_1.py
@@ -1,9 +1,9 @@
 """
-    DSNS-239
-    R3.1 Process a scene if the ancillary is not there,
-    after the wait time (Process to interim)
+    DSNS 237
+        R2.8.1 Filter out ls8 l1 scenes if the dataset has a child,
+        the child is interim and there is no ancillary
 """
-from collections import Counter
+
 from pathlib import Path
 import os
 import json
@@ -14,7 +14,6 @@ from scene_select.do_ard import ODC_FILTERED_FILE
 
 from util import (
     get_list_from_file,
-    get_expected_file_paths,
 )
 
 METADATA_DIR = (
@@ -30,9 +29,14 @@ PRODUCTS_DIR = (
 )
 
 PRODUCTS = [
+    os.path.join(PRODUCTS_DIR, "l1_ls7.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "l1_ls8.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "l1_ls8_c2.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "l1_ls9.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "ard_ls7.odc-product.yaml"),
+    os.path.join(PRODUCTS_DIR, "ard_ls9.odc-product.yaml"),
 ]
 
 DATASETS_DIR = (
@@ -44,35 +48,33 @@ DATASETS_DIR = (
     )
     .resolve()
 )
+
 DATASETS = [
+    # usgs_ls8c_level1_2
     os.path.join(
         DATASETS_DIR,
-        "c3/LC81020792023029_do_interim/LC08_L1GT_102079_20230129_20230227_02_T2.odc-metadata.yaml",
+        "c3/LC80960702022336_do_interim/LC08_L1TP_096070_20221202_20221212_02_T1.odc-metadata.yaml",
+    ),
+    # ga_ls8c_ard_3
+    os.path.join(
+        DATASETS_DIR,
+        "c3/LC80960702022336_ard/ga_ls8c_ard_3-2-1_096070_2022-12-02_interim.odc-metadata.yaml",
     ),
 ]
 
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_interim_prod_r_3_1(tmp_path):
+def test_scene_filtering_r2_8_1(tmp_path):
     """
     This is the collective test that implements the requirement as
     defined at the top of this test suite.
     """
-
-    # Observe that there is a date exclusion filter passed
-    # into the process
     cmd_params = [
         "--products",
-        '[ "usgs_ls8c_level1_2" ]',
+        '[ "usgs_ls8c_level1_1", "usgs_ls8c_level1_2"]',
         "--logdir",
         tmp_path,
-        "--allowed-codes",
-        "Australian_AOI_107069_added.json",
-        "--days-to-exclude",
-        '["2009-01-03:2009-01-05"]',
-        "--interim-days-wait",
-        5,
     ]
 
     runner = CliRunner()
@@ -92,30 +94,25 @@ def test_interim_prod_r_3_1(tmp_path):
         matching_files and matching_files[0] is not None
     ), f"Scene select failed. Log is not available - {matching_files}"
 
-    assert matching_files and matching_files[0] is not None, (
-        "Scene select failed. List of entries to process is not available -",
-        f" {matching_files}",
-    )
-
     found_log_line = False
     with open(matching_files[0], encoding="utf-8") as ard_log_file:
         for line in ard_log_file:
             try:
                 jline = json.loads(line)
                 if (
-                    all(key in jline for key in ("event", "landsat_scene_id", "level"))
-                    and jline["event"] == "No ancillary. Processing to interim"
-                    and jline["landsat_scene_id"]
-                    == "LC08_L1GT_102079_20230129_20230227_02_T2"
-                    and jline["level"] == "debug"
+                    all(key in jline for key in ("reason", "dataset_id", "event"))
+                    and jline["reason"] == "The scene has been processed"
+                    and jline["dataset_id"] == "768675cd-0c2b-5a17-871a-1f35eabac78e"
+                    and jline["event"] == "scene removed"
                 ):
                     found_log_line = True
                     break
             except json.JSONDecodeError as error_string:
                 print(f"Error decoding JSON: {error_string}")
-    assert (
-        found_log_line
-    ), "Landsat scene still selected despite its date is being excluded"
+    assert found_log_line, (
+        "Landsat scene still selected despite the dataset has a child (where ",
+        "the child is interim and there is no ancillary)",
+    )
 
     # Use glob to search for the scenes_to_ARD_process.txt file
     # within filter-jobid-* directories
@@ -127,8 +124,13 @@ def test_interim_prod_r_3_1(tmp_path):
         f"Scene select failed. List of entries to process is not available :{ODC_FILTERED_FILE} "
         f"- {matching_files}"
     )
+
     ards_to_process = get_list_from_file(matching_files[0])
-    expected_files = get_expected_file_paths(DATASETS)
-    assert Counter(ards_to_process) == Counter(
-        expected_files
-    ), "Lists do not have the same contents."
+
+    # Given that the run should have no ards to process, we expect
+    # an empty scenes_to_ARD_process.txt file.
+
+    assert len(ards_to_process) == 0, (
+        "Ard entries to process exist when we are not expecting "
+        f"anything to be there, {ards_to_process}"
+    )

--- a/tests/integration_tests/test_scene_r3_3.py
+++ b/tests/integration_tests/test_scene_r3_3.py
@@ -1,6 +1,7 @@
 """
-    DSNS-236
-    R2.6 Filter out l1 scenes if the dataset has a child and the child is not archived
+    DSNS-231
+       R3.3 Filter out the l1 scene if there is already an ARD scene with the
+       same scene_id, that is un-archived.
 """
 from pathlib import Path
 import os
@@ -9,9 +10,10 @@ from click.testing import CliRunner
 import pytest
 from scene_select.ard_scene_select import scene_select, GEN_LOG_FILE
 from scene_select.do_ard import ODC_FILTERED_FILE
-
+import datacube
 from util import (
     get_list_from_file,
+    get_config_file_contents,
 )
 
 METADATA_DIR = (
@@ -28,7 +30,6 @@ PRODUCTS_DIR = (
 
 PRODUCTS = [
     os.path.join(PRODUCTS_DIR, "l1_ls8.odc-product.yaml"),
-    os.path.join(PRODUCTS_DIR, "l1_ls8_c2.odc-product.yaml"),
     os.path.join(PRODUCTS_DIR, "ard_ls8.odc-product.yaml"),
 ]
 
@@ -41,36 +42,42 @@ DATASETS_DIR = (
     )
     .resolve()
 )
+
 DATASETS = [
     os.path.join(
         DATASETS_DIR,
-        "c3/LC80900742020304/LC08_L1GT_090074_20201030_20201106_01_T2.odc-metadata.yaml",
+        "c3/LC81150802019349/LC08_L1TP_115080_20191215_20191226_01_T1.odc-metadata.yaml",
     ),
     os.path.join(
         DATASETS_DIR,
-        "c3/ARD_LC80900742020304_final/ga_ls8c_ard_3-1-0_090074_2020-10-30_final.odc-metadata.yaml",
+        "c3/LC81150802019349/LC08_L1TP_115080_20191215_20201023_01_T1.odc-metadata.yaml",
     ),
     os.path.join(
         DATASETS_DIR,
-        "c3/LC80960702022336_do_interim/LC08_L1TP_096070_20221202_20221212_02_T1.odc-metadata.yaml",
-    ),
-    os.path.join(
-        DATASETS_DIR,
-        "c3/LC80960702022336_ard/ga_ls8c_ard_3-2-1_096070_2022-12-02_interim.odc-metadata.yaml",
+        "c3/ARD_LC81150802019349_old/ga_ls8c_ard_3-1-0_115080_2019-12-15_final.odc-metadata.yaml",
     ),
 ]
+
+
+def generate_temp_config_file(tmp_path):
+    test_config_file = os.path.abspath(tmp_path / "config_file.conf")
+    config_file_contents = get_config_file_contents()
+    with open(test_config_file, "w", encoding="utf-8") as config_file_handler:
+        config_file_handler.write(config_file_contents)
+    config_file_handler.close()
+    return test_config_file
+
 
 pytestmark = pytest.mark.usefixtures("auto_odc_db")
 
 
-def test_scene_filtering_r_2_6(tmp_path):
+def test_scene_r3_3(odc_test_db: datacube.Datacube, tmp_path):
     """
     This is the collective test that implements the requirement as
     defined at the top of this test suite.
     """
+    odc_test_db.index.datasets.archive(["760315b3-e147-5db2-bb7f-0e52efd4453d"])
 
-    # Observe that there is a date exclusion filter passed
-    # into the process
     cmd_params = [
         "--products",
         '[ "usgs_ls8c_level1_1" ]',
@@ -86,6 +93,26 @@ def test_scene_filtering_r_2_6(tmp_path):
 
     assert result.exit_code == 0, "The scene_select process failed to execute"
 
+    # Use glob to search for the scenes_to_ARD_process.txt file
+    # within filter-jobid-* directories
+    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
+
+    # There's only ever 1 copy of scenes_to_ARD_process.txt after
+    # successfully processing
+    assert matching_files and matching_files[0] is not None, (
+        "Scene select failed. List of entries to process is not available - ",
+        f"{matching_files}",
+    )
+    ards_to_process = get_list_from_file(matching_files[0])
+
+    # Given that the run should have no ards to process, we expect
+    # an empty scenes_to_ARD_process.txt file.
+
+    assert len(ards_to_process) == 0, (
+        "Ard entries to process exist when we are not expecting anything",
+        " to be there",
+    )
+
     # Use glob to search for the log file
     # within filter-jobid-* directories
     matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + GEN_LOG_FILE))
@@ -95,46 +122,25 @@ def test_scene_filtering_r_2_6(tmp_path):
         matching_files and matching_files[0] is not None
     ), f"Scene select failed. Log is not available - {matching_files}"
 
-    assert matching_files and matching_files[0] is not None, (
-        "Scene select failed. List of entries to process is not available -",
-        f" {matching_files}",
-    )
-
     found_log_line = False
+
     with open(matching_files[0], encoding="utf-8") as ard_log_file:
         for line in ard_log_file:
             try:
                 jline = json.loads(line)
                 if (
-                    all(key in jline for key in ("reason", "dataset_id", "event"))
+                    all(key in jline for key in ("reason", "event", "landsat_scene_id"))
                     and jline["reason"] == "The scene has been processed"
-                    and jline["dataset_id"] == "91f2fbd8-8ad5-550b-a62c-d819e1a4baaa"
                     and jline["event"] == "scene removed"
+                    and jline["landsat_scene_id"]
+                    == "LC08_L1TP_115080_20191215_20201023_01_T1"
                 ):
                     found_log_line = True
                     break
             except json.JSONDecodeError as error_string:
                 print(f"Error decoding JSON: {error_string}")
-    assert (
-        found_log_line
-    ), "Landsat scene still selected despite its date is being excluded"
 
-    # Use glob to search for the scenes_to_ARD_process.txt file
-    # within filter-jobid-* directories
-    matching_files = list(Path(tmp_path).glob("filter-jobid-*/" + ODC_FILTERED_FILE))
-
-    # There's only ever 1 copy of scenes_to_ARD_process.txt after
-    # successfully processing
-    assert matching_files and matching_files[0] is not None, (
-        f"Scene select failed. List of entries to process is not available :{ODC_FILTERED_FILE} "
-        f"- {matching_files}"
-    )
-    ards_to_process = get_list_from_file(matching_files[0])
-
-    # Given that the run should have no ards to process, we expect
-    # an empty scenes_to_ARD_process.txt file.
-
-    assert len(ards_to_process) == 0, (
-        "Ard entries to process exist when we are not expecting "
-        f"anything to be there, {ards_to_process}"
+    assert found_log_line, (
+        "landsat scene still selected despite there is already an ARD scene",
+        " with the same id and its initial scene had been archived",
     )


### PR DESCRIPTION
    -Made existing test file names consistent (ie. r<version number> as opposed to r_<version number> for landsat tests)
    -Relabelled test requirements in db_index.sh and split some existing tests to their rightful test files
    -Introduced a new test file for R2.8.2 for landsat tests