### PR TITLE
Sort files by recent acquisitions first

### DIFF
--- a/scene_select/ard_scene_select.py
+++ b/scene_select/ard_scene_select.py
@@ -506,7 +506,21 @@ def l1_filter(
 
         files2process.add(file_path)
 
-    return list(files2process), uuids2archive, duplicates
+    # Sort files so most recent are processed first.
+    # This is to avoid a backlog holding up recent acquisitions
+    return sorted(files2process, key=_get_path_date, reverse=True), uuids2archive, duplicates
+
+
+def _get_path_date(path: str) -> str:
+    """
+    >>> _get_path_date('/g/data/da82/AODH/USGS/L1/Landsat/C2/135_097/LC81350972022337/LC08_L1GT_135097_20221203_20221212_02_T2.tar')
+    '20221203'
+    """
+    try:
+        return path.split('_')[4]
+    except IndexError:
+        # If the filename doesn't follow that pattern, just sort it last
+        return '00000000'
 
 
 def l1_scenes_to_process(

--- a/scene_select/utils.py
+++ b/scene_select/utils.py
@@ -11,6 +11,7 @@ import yaml
 import click
 
 from datacube import Datacube
+from datacube.model import Dataset
 
 DATA_DIR = Path(__file__).parent.joinpath("data")
 
@@ -30,7 +31,7 @@ INSIGNIFICANT_DIGITS_FIX = [
 ]
 
 
-def calc_file_path(l1_dataset, product_id):
+def calc_file_path(l1_dataset: Dataset, product_id: str) -> str:
     if l1_dataset.local_path is None:
         # The s2 way
         file_path = calc_local_path(l1_dataset)
@@ -44,7 +45,7 @@ def calc_file_path(l1_dataset, product_id):
     return file_path
 
 
-def calc_local_path(l1_dataset):
+def calc_local_path(l1_dataset: Dataset) -> str:
     assert len(l1_dataset.uris) == 1, str(l1_dataset.uris)
     components = urlparse(l1_dataset.uris[0])
     if not (components.scheme == "file" or components.scheme == "zip"):


### PR DESCRIPTION
This is to prevent a backlog from holding up the most recent acquisitions.

We could be a little smarter in the future, but this will help with surges like our recent one.

For non-landsat paths it falls back to unsorted (ie, the old behaviour)